### PR TITLE
Use std::shared_ptr for message handlers

### DIFF
--- a/wfd/common/message_handler.h
+++ b/wfd/common/message_handler.h
@@ -36,12 +36,19 @@ namespace wfd {
 
 class MediaManager;
 
-class MessageHandler {
+class MessageHandler;
+using MessageHandlerPtr = std::shared_ptr<MessageHandler>;
+
+inline MessageHandlerPtr make_ptr(MessageHandler* handler) {
+  return MessageHandlerPtr(handler);
+}
+
+class MessageHandler : public std::enable_shared_from_this<MessageHandler> {
  public:
   class Observer {
    public:
-    virtual void OnCompleted(MessageHandler* handler) {}
-    virtual void OnError(MessageHandler* handler) {}
+    virtual void OnCompleted(MessageHandlerPtr handler) {}
+    virtual void OnError(MessageHandlerPtr handler) {}
 
    protected:
     virtual ~Observer() {}
@@ -106,13 +113,13 @@ class MessageSequenceHandler : public MessageHandler,
   virtual bool HandleTimeoutEvent(uint timer_id) const override;
 
  protected:
-  void AddSequencedHandler(MessageHandler* handler);
+  void AddSequencedHandler(MessageHandlerPtr handler);
   // MessageHandler::Observer implementation.
-  virtual void OnCompleted(MessageHandler* handler) override;
-  virtual void OnError(MessageHandler* handler) override;
+  virtual void OnCompleted(MessageHandlerPtr handler) override;
+  virtual void OnError(MessageHandlerPtr handler) override;
 
-  std::vector<MessageHandler*> handlers_;
-  MessageHandler* current_handler_;
+  std::vector<MessageHandlerPtr> handlers_;
+  MessageHandlerPtr current_handler_;
 };
 
 class MessageSequenceWithOptionalSetHandler : public MessageSequenceHandler {
@@ -129,12 +136,12 @@ class MessageSequenceWithOptionalSetHandler : public MessageSequenceHandler {
   virtual bool HandleTimeoutEvent(uint timer_id) const override;
 
  protected:
-  void AddOptionalHandler(MessageHandler* handler);
+  void AddOptionalHandler(MessageHandlerPtr handler);
   // MessageHandler::Observer implementation.
-  virtual void OnCompleted(MessageHandler* handler) override;
-  virtual void OnError(MessageHandler* handler) override;
+  virtual void OnCompleted(MessageHandlerPtr handler) override;
+  virtual void OnError(MessageHandlerPtr handler) override;
 
-  std::vector<MessageHandler*> optional_handlers_;
+  std::vector<MessageHandlerPtr> optional_handlers_;
 };
 
 // This is aux classes to handle single message.

--- a/wfd/sink/cap_negotiation_state.cpp
+++ b/wfd/sink/cap_negotiation_state.cpp
@@ -147,12 +147,12 @@ class M5Handler final : public MessageReceiver<Request::M5> {
 
 CapNegotiationState::CapNegotiationState(const InitParams &init_params)
   : MessageSequenceWithOptionalSetHandler(init_params) {
-  AddSequencedHandler(new M3Handler(init_params));
-  AddSequencedHandler(new M4Handler(init_params));
-  AddSequencedHandler(new M5Handler(init_params));
+  AddSequencedHandler(make_ptr(new M3Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M4Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M5Handler(init_params)));
 
-  AddOptionalHandler(new M3Handler(init_params));
-  AddOptionalHandler(new M4Handler(init_params));
+  AddOptionalHandler(make_ptr(new M3Handler(init_params)));
+  AddOptionalHandler(make_ptr(new M4Handler(init_params)));
 }
 
 CapNegotiationState::~CapNegotiationState() {

--- a/wfd/sink/init_state.cpp
+++ b/wfd/sink/init_state.cpp
@@ -74,8 +74,8 @@ class M2Handler final : public SequencedMessageSender {
 
 InitState::InitState(const InitParams& init_params)
   : MessageSequenceHandler(init_params) {
-  AddSequencedHandler(new M1Handler(init_params));
-  AddSequencedHandler(new M2Handler(init_params));
+  AddSequencedHandler(make_ptr(new M1Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M2Handler(init_params)));
 }
 
 InitState::~InitState() {

--- a/wfd/sink/sink.cpp
+++ b/wfd/sink/sink.cpp
@@ -69,10 +69,10 @@ class SinkStateMachine : public MessageSequenceHandler {
  public:
    SinkStateMachine(const InitParams& init_params)
      : MessageSequenceHandler(init_params) {
-     AddSequencedHandler(new sink::InitState(init_params));
-     AddSequencedHandler(new sink::CapNegotiationState(init_params));
-     AddSequencedHandler(new sink::WfdSessionState(init_params));
-     AddSequencedHandler(new sink::StreamingState(init_params));
+     AddSequencedHandler(make_ptr(new sink::InitState(init_params)));
+     AddSequencedHandler(make_ptr(new sink::CapNegotiationState(init_params)));
+     AddSequencedHandler(make_ptr(new sink::WfdSessionState(init_params)));
+     AddSequencedHandler(make_ptr(new sink::StreamingState(init_params)));
    }
    SinkStateMachine(Peer::Delegate* sender, SinkMediaManager* mng)
      : SinkStateMachine({sender, mng, this}) {}

--- a/wfd/sink/streaming_state.cpp
+++ b/wfd/sink/streaming_state.cpp
@@ -79,8 +79,8 @@ class PlayHandler : public MessageSequenceHandler {
  public:
   explicit PlayHandler(const InitParams& init_params)
   : MessageSequenceHandler(init_params) {
-    AddSequencedHandler(new M5Handler<TriggerMethod::PLAY>(init_params));
-    AddSequencedHandler(new M7Sender(init_params));
+    AddSequencedHandler(make_ptr(new M5Handler<TriggerMethod::PLAY>(init_params)));
+    AddSequencedHandler(make_ptr(new M7Sender(init_params)));
   }
 };
 
@@ -106,8 +106,8 @@ class M8Sender final : public SequencedMessageSender {
 
 TeardownHandler::TeardownHandler(const InitParams& init_params)
   : MessageSequenceHandler(init_params) {
-  AddSequencedHandler(new M5Handler<wfd::TriggerMethod::TEARDOWN>(init_params));
-  AddSequencedHandler(new M8Sender(init_params));
+  AddSequencedHandler(make_ptr(new M5Handler<wfd::TriggerMethod::TEARDOWN>(init_params)));
+  AddSequencedHandler(make_ptr(new M8Sender(init_params)));
 }
 
 class M9Sender final : public SequencedMessageSender {
@@ -134,8 +134,8 @@ class PauseHandler : public MessageSequenceHandler {
  public:
   explicit PauseHandler(const InitParams& init_params)
   : MessageSequenceHandler(init_params) {
-    AddSequencedHandler(new M5Handler<TriggerMethod::PAUSE>(init_params));
-    AddSequencedHandler(new M9Sender(init_params));
+    AddSequencedHandler(make_ptr(new M5Handler<TriggerMethod::PAUSE>(init_params)));
+    AddSequencedHandler(make_ptr(new M9Sender(init_params)));
   }
 };
 
@@ -202,16 +202,16 @@ class M9SenderOptional final : public OptionalMessageSender<Request::M9> {
 
 StreamingState::StreamingState(const InitParams& init_params)
   : MessageSequenceWithOptionalSetHandler(init_params) {
-  AddSequencedHandler(new TeardownHandler(init_params));
-  AddOptionalHandler(new PlayHandler(init_params));
-  AddOptionalHandler(new PauseHandler(init_params));
-  AddOptionalHandler(new M3Handler(init_params));
-  AddOptionalHandler(new M4Handler(init_params));
+  AddSequencedHandler(make_ptr(new TeardownHandler(init_params)));
+  AddOptionalHandler(make_ptr(new PlayHandler(init_params)));
+  AddOptionalHandler(make_ptr(new PauseHandler(init_params)));
+  AddOptionalHandler(make_ptr(new M3Handler(init_params)));
+  AddOptionalHandler(make_ptr(new M4Handler(init_params)));
 
   // optional senders that handle sending play, pause and teardown
-  AddOptionalHandler(new M7SenderOptional(init_params));
-  AddOptionalHandler(new M8SenderOptional(init_params));
-  AddOptionalHandler(new M9SenderOptional(init_params));
+  AddOptionalHandler(make_ptr(new M7SenderOptional(init_params)));
+  AddOptionalHandler(make_ptr(new M8SenderOptional(init_params)));
+  AddOptionalHandler(make_ptr(new M9SenderOptional(init_params)));
 }
 
 StreamingState::~StreamingState() {

--- a/wfd/sink/wfd_session_state.cpp
+++ b/wfd/sink/wfd_session_state.cpp
@@ -81,12 +81,12 @@ class M7Handler final : public SequencedMessageSender {
 
 WfdSessionState::WfdSessionState(const InitParams& init_params)
   : MessageSequenceWithOptionalSetHandler(init_params) {
-  AddSequencedHandler(new M6Handler(init_params));
-  AddSequencedHandler(new M7Handler(init_params));
+  AddSequencedHandler(make_ptr(new M6Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M7Handler(init_params)));
 
-  AddOptionalHandler(new M3Handler(init_params));
-  AddOptionalHandler(new M4Handler(init_params));
-  AddOptionalHandler(new TeardownHandler(init_params));
+  AddOptionalHandler(make_ptr(new M3Handler(init_params)));
+  AddOptionalHandler(make_ptr(new M4Handler(init_params)));
+  AddOptionalHandler(make_ptr(new TeardownHandler(init_params)));
 }
 
 WfdSessionState::~WfdSessionState() {

--- a/wfd/source/cap_negotiation_state.cpp
+++ b/wfd/source/cap_negotiation_state.cpp
@@ -93,8 +93,8 @@ bool M4Handler::HandleReply(Reply* reply) {
 
 CapNegotiationState::CapNegotiationState(const InitParams &init_params)
   : MessageSequenceHandler(init_params) {
-  AddSequencedHandler(new M3Handler(init_params));
-  AddSequencedHandler(new M4Handler(init_params));
+  AddSequencedHandler(make_ptr(new M3Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M4Handler(init_params)));
 }
 
 CapNegotiationState::~CapNegotiationState() {

--- a/wfd/source/init_state.cpp
+++ b/wfd/source/init_state.cpp
@@ -67,8 +67,8 @@ class M2Handler final : public MessageReceiver<Request::M2> {
 
 InitState::InitState(const InitParams& init_params)
   : MessageSequenceHandler(init_params) {
-  AddSequencedHandler(new M1Handler(init_params));
-  AddSequencedHandler(new M2Handler(init_params));
+  AddSequencedHandler(make_ptr(new M1Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M2Handler(init_params)));
 }
 
 InitState::~InitState() {

--- a/wfd/source/source.cpp
+++ b/wfd/source/source.cpp
@@ -82,10 +82,10 @@ class SourceStateMachine : public MessageSequenceHandler {
  public:
    SourceStateMachine(const InitParams& init_params)
      : MessageSequenceHandler(init_params) {
-     AddSequencedHandler(new source::InitState(init_params));
-     AddSequencedHandler(new source::CapNegotiationState(init_params));
-     AddSequencedHandler(new source::WfdSessionState(init_params));
-     AddSequencedHandler(new source::StreamingState(init_params));
+     AddSequencedHandler(make_ptr(new source::InitState(init_params)));
+     AddSequencedHandler(make_ptr(new source::CapNegotiationState(init_params)));
+     AddSequencedHandler(make_ptr(new source::WfdSessionState(init_params)));
+     AddSequencedHandler(make_ptr(new source::StreamingState(init_params)));
    }
 
    int GetNextCSeq() { return send_cseq_++; }
@@ -104,8 +104,8 @@ class SourceImpl final : public Source, public RTSPInputHandler, public MessageH
   virtual bool Pause() override;
 
   // public MessageHandler::Observer
-  virtual void OnCompleted(MessageHandler* handler) override;
-  virtual void OnError(MessageHandler* handler) override;
+  virtual void OnCompleted(MessageHandlerPtr handler) override;
+  virtual void OnError(MessageHandlerPtr handler) override;
 
   virtual void OnTimerEvent(uint timer_id) override;
 
@@ -176,9 +176,9 @@ bool SourceImpl::Pause() {
   return true;
 }
 
-void SourceImpl::OnCompleted(MessageHandler* handler) {}
+void SourceImpl::OnCompleted(MessageHandlerPtr handler) {}
 
-void SourceImpl::OnError(MessageHandler* handler) {}
+void SourceImpl::OnError(MessageHandlerPtr handler) {}
 
 void SourceImpl::MessageParsed(std::unique_ptr<Message> message) {
   if (message->is_request() && !InitializeRequestId(ToRequest(message.get())))

--- a/wfd/source/streaming_state.cpp
+++ b/wfd/source/streaming_state.cpp
@@ -58,11 +58,11 @@ class M5Sender final : public OptionalMessageSender<Request::M5> {
 
 StreamingState::StreamingState(const InitParams& init_params)
   : MessageSequenceWithOptionalSetHandler(init_params) {
-  AddSequencedHandler(new M8Handler(init_params));
+  AddSequencedHandler(make_ptr(new M8Handler(init_params)));
 
-  AddOptionalHandler(new M5Sender(init_params));
-  AddOptionalHandler(new M7Handler(init_params));
-  AddOptionalHandler(new M9Handler(init_params));
+  AddOptionalHandler(make_ptr(new M5Sender(init_params)));
+  AddOptionalHandler(make_ptr(new M7Handler(init_params)));
+  AddOptionalHandler(make_ptr(new M9Handler(init_params)));
 }
 
 StreamingState::~StreamingState() {

--- a/wfd/source/wfd_session_state.cpp
+++ b/wfd/source/wfd_session_state.cpp
@@ -95,11 +95,11 @@ std::unique_ptr<Reply> M8Handler::HandleMessage(Message* message) {
 
 WfdSessionState::WfdSessionState(const InitParams& init_params)
   : MessageSequenceWithOptionalSetHandler(init_params) {
-  AddSequencedHandler(new M5Handler(init_params));
-  AddSequencedHandler(new M6Handler(init_params));
-  AddSequencedHandler(new M7Handler(init_params));
+  AddSequencedHandler(make_ptr(new M5Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M6Handler(init_params)));
+  AddSequencedHandler(make_ptr(new M7Handler(init_params)));
 
-  AddOptionalHandler(new M8Handler(init_params));
+  AddOptionalHandler(make_ptr(new M8Handler(init_params)));
 }
 
 WfdSessionState::~WfdSessionState() {


### PR DESCRIPTION
So that message handler instances can be shared between states.