### PR TITLE
P2p new connman api

### DIFF
--- a/desktop_source/main.cpp
+++ b/desktop_source/main.cpp
@@ -33,7 +33,7 @@
 
 struct SourceAppData {
     std::unique_ptr<MiracBrokerSource> source;
-    std::unique_ptr<ConnmanClient> connman;
+    std::unique_ptr<P2P::Client> p2p_client;
 
     int port;
 };
@@ -136,7 +136,7 @@ int main (int argc, char *argv[])
 
     // register the P2P service with connman
     auto array = ie.serialize ();
-    data.connman.reset(new ConnmanClient (array));
+    data.p2p_client.reset(new P2P::Client (array));
     data.source.reset(new MiracBrokerSource(data.port));
     g_main_loop_run (main_loop);
 

--- a/p2p/CMakeLists.txt
+++ b/p2p/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_check_modules (GIO REQUIRED gio-2.0)
 include_directories(${GIO_INCLUDE_DIRS})
 
 add_library(p2p STATIC
-    connman-client.cpp information-element.cpp
+    connman-peer.cpp connman-client.cpp information-element.cpp
 )
 
 add_executable(register-peer-service main.cpp)

--- a/p2p/connman-client.cpp
+++ b/p2p/connman-client.cpp
@@ -33,7 +33,7 @@ void Client::proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char 
     if (g_strcmp0(signal, "PeersChanged") != 0)
         return;
 
-    auto client = reinterpret_cast<Client*> (data_ptr);
+    auto client = static_cast<Client*> (data_ptr);
     client->peers_changed (params);
 }
 
@@ -65,7 +65,7 @@ void Client::get_peers_cb (GObject *object, GAsyncResult *res, gpointer data_ptr
     }
 
     g_variant_get(params, "(a(oa{sv}))", &peer_iter);
-    auto client = reinterpret_cast<Client*>(data_ptr);
+    auto client = static_cast<Client*>(data_ptr);
     client->handle_new_peers(peer_iter);
 
     g_variant_unref(params);
@@ -91,14 +91,14 @@ void Client::scan_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
 /* static C callback */
 void Client::proxy_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
 {
-    auto client = reinterpret_cast<Client*> (data_ptr);
+    auto client = static_cast<Client*> (data_ptr);
     client->proxy_cb (res);
 }
 
 /* static C callback */
 void Client::technology_proxy_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
 {
-    auto client = reinterpret_cast<Client*> (data_ptr);
+    auto client = static_cast<Client*> (data_ptr);
     client->technology_proxy_cb (res);
 }
 

--- a/p2p/connman-client.cpp
+++ b/p2p/connman-client.cpp
@@ -145,6 +145,12 @@ void Client::peers_changed (GVariant *params)
 void Client::register_peer_service ()
 {
     GVariantBuilder builder;
+
+    /* HACK: Connman should figure out the "master" boolean on its own but it does not.
+     * We need to do it here with InformationElement for now... */
+    P2P::InformationElement ie(array_);
+    bool is_master = (ie.get_device_type() != P2P::SOURCE);
+
     g_variant_builder_init (&builder, G_VARIANT_TYPE("a{sv}"));
     g_variant_builder_add (&builder, "{sv}",
                            "WiFiDisplayIEs",
@@ -155,7 +161,7 @@ void Client::register_peer_service ()
 
     g_dbus_proxy_call (proxy_,
                        "RegisterPeerService",
-                       g_variant_new ("(a{sv}b)", &builder, TRUE),
+                       g_variant_new ("(a{sv}b)", &builder, is_master),
                        G_DBUS_CALL_FLAGS_NONE,
                        -1,
                        NULL,

--- a/p2p/connman-client.cpp
+++ b/p2p/connman-client.cpp
@@ -96,12 +96,15 @@ void ConnmanClient::peers_changed (GVariant *params)
 
     }
 
-
     while (g_variant_iter_loop (removed, "o", &path)) {
-        /* TODO call on_peer_removed() */
-        if (peers_.erase (path) > 0) {
-            std::cout << "removed peer " << path << std::endl;
-        }
+        auto it = peers_.find(path);
+        if (it == peers_.end())
+			return;
+
+        if (observer_)
+            observer_->on_peer_removed(this, it->second);
+
+        peers_.erase(it);
     }
 
     g_variant_iter_free (added);

--- a/p2p/connman-client.cpp
+++ b/p2p/connman-client.cpp
@@ -189,6 +189,9 @@ void ConnmanClient::proxy_cb (GAsyncResult *result)
     /* TODO run GetPeers just in case the list is up to date already */
 
     register_peer_service();
+
+	if(technology_proxy_ && observer_)
+		observer_->on_initialized(this);
 }
 
 void ConnmanClient::technology_proxy_cb (GAsyncResult *result)
@@ -200,10 +203,14 @@ void ConnmanClient::technology_proxy_cb (GAsyncResult *result)
         std::cout << "tech proxy error "<< std::endl;
         g_clear_error (&error);
     }
+
+	if(proxy_ && observer_)
+		observer_->on_initialized(this);
 }
 
 ConnmanClient::ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array):
     proxy_(NULL),
+    observer_(NULL),
     array_(std::move(take_array))
 {
     g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -28,21 +28,23 @@
 #include "information-element.h"
 #include "connman-peer.h"
 
-class ConnmanClient {
+namespace P2P {
+
+class Client {
     public:
 		class Observer {
 			public:
-				virtual void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) {}
-				virtual void on_peer_removed(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) {}
-				virtual void on_initialized(ConnmanClient *client) {}
+				virtual void on_peer_added(Client *client, std::shared_ptr<P2P::Peer> peer) {}
+				virtual void on_peer_removed(Client *client, std::shared_ptr<P2P::Peer> peer) {}
+				virtual void on_initialized(Client *client) {}
 
 			protected:
 				virtual ~Observer() {}
 		};
 
-        ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array);
-        ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array, Observer *observer);
-        virtual ~ConnmanClient();
+        Client(std::unique_ptr<P2P::InformationElementArray> &take_array);
+        Client(std::unique_ptr<P2P::InformationElementArray> &take_array, Observer *observer);
+        virtual ~Client();
 
         void set_information_element(std::unique_ptr<P2P::InformationElementArray> &take_array);
 		void set_observer(Observer* observer) {
@@ -74,4 +76,5 @@ class ConnmanClient {
 		std::map<std::string, std::shared_ptr<P2P::Peer>> peers_;
 };
 
+}
 #endif // CONNMAN_CLIENT_H_

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -54,17 +54,19 @@ class Client {
 		/* TODO error / finished handling */
 		void scan();
 
-    private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
         static void proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void technology_proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void register_peer_service_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void scan_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
+        static void get_peers_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
 
         void peers_changed (GVariant *params);
         void proxy_cb(GAsyncResult *res);
         void technology_proxy_cb(GAsyncResult *res);
+        void handle_new_peers(GVariantIter *added);
 
+        void initialize_peers();
         void register_peer_service();
         void unregister_peer_service();
 

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -32,7 +32,8 @@ class ConnmanClient {
     public:
 		class Observer {
 			public:
-				virtual void on_peers_changed(ConnmanClient *client) {}
+				virtual void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) {}
+				// virtual void on_peer_removed(ConnmanClient *client) {}
 				virtual void on_initialized(ConnmanClient *client) {}
 
 			protected:
@@ -40,6 +41,7 @@ class ConnmanClient {
 		};
 
         ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array);
+        ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array, Observer *observer);
         virtual ~ConnmanClient();
 
         void set_information_element(std::unique_ptr<P2P::InformationElementArray> &take_array);

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -35,22 +35,27 @@ class ConnmanClient {
 
         void set_information_element(std::unique_ptr<P2P::InformationElementArray> &take_array);
 		
-		// TODO scan()   (for source)
-		// TODO Observer for changes in peer list   (for source)
+		void scan();
+
+		// TODO Observer for changes in peers_
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
         static void proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
+        static void technology_proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void register_peer_service_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
+        static void scan_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
 
         void peers_changed (GVariant *params);
-        void proxy_cb(GObject *object, GAsyncResult *res);
-        void register_peer_service_cb(GObject *object, GAsyncResult *res);
+        void proxy_cb(GAsyncResult *res);
+        void technology_proxy_cb(GAsyncResult *res);
 
         void register_peer_service();
         void unregister_peer_service();
 
         GDBusProxy *proxy_;
+        GDBusProxy *technology_proxy_;
+
         std::unique_ptr<P2P::InformationElementArray>array_;
 		std::map<std::string, std::shared_ptr<P2P::Peer>> peers_;
 };

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -33,7 +33,7 @@ class ConnmanClient {
 		class Observer {
 			public:
 				virtual void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) {}
-				// virtual void on_peer_removed(ConnmanClient *client) {}
+				virtual void on_peer_removed(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) {}
 				virtual void on_initialized(ConnmanClient *client) {}
 
 			protected:

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -30,14 +30,23 @@
 
 class ConnmanClient {
     public:
+		class Observer {
+			public:
+				virtual void on_peers_changed(ConnmanClient *client) {}
+
+			protected:
+				virtual ~Observer() {}
+		};
+
         ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array);
         virtual ~ConnmanClient();
 
         void set_information_element(std::unique_ptr<P2P::InformationElementArray> &take_array);
-		
-		void scan();
+		void set_observer(Observer* observer) {
+			observer_ = observer;
+		}
 
-		// TODO Observer for changes in peers_
+		void scan();
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
@@ -56,6 +65,7 @@ class ConnmanClient {
         GDBusProxy *proxy_;
         GDBusProxy *technology_proxy_;
 
+		Observer* observer_;
         std::unique_ptr<P2P::InformationElementArray>array_;
 		std::map<std::string, std::shared_ptr<P2P::Peer>> peers_;
 };

--- a/p2p/connman-client.h
+++ b/p2p/connman-client.h
@@ -33,6 +33,7 @@ class ConnmanClient {
 		class Observer {
 			public:
 				virtual void on_peers_changed(ConnmanClient *client) {}
+				virtual void on_initialized(ConnmanClient *client) {}
 
 			protected:
 				virtual ~Observer() {}
@@ -46,6 +47,7 @@ class ConnmanClient {
 			observer_ = observer;
 		}
 
+		/* TODO error / finished handling */
 		void scan();
 
     private:

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -86,10 +86,13 @@ void Peer::ip_changed (char *ip)
 	
 	ip_address_ = new_ip;
 
+	if (!observer_)
+		return;
+
 	if (ip_address_.empty() && ready_) {
-		// TODO notify observer: peer is no longer ok
+		observer_->on_state_changed(this);
 	} else if (!ip_address_.empty() && ready_) {
-		// TODO Notify observer: peer is now ok
+		observer_->on_state_changed(this);
 	}
 }
 
@@ -100,14 +103,17 @@ void Peer::state_changed (bool ready)
 	
 	ready_ = ready;
 
+	if (!observer_)
+		return;
+
 	if (!ready_ && !ip_address_.empty())
-		// TODO Notify observer: peer is no longer ok
+		observer_->on_state_changed(this);
 	if (ready_ && !ip_address_.empty()) {
-		// TODO Notify observer: peer is now ok
+		observer_->on_state_changed(this);
 	}
 }
 
-Peer::Peer(std::string object_path, std::shared_ptr<P2P::InformationElement> ie):
+Peer::Peer(const std::string& object_path, std::shared_ptr<P2P::InformationElement> ie):
     ie_(ie)
 {
     g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -150,7 +150,11 @@ void Peer::remote_ip_changed (const char *ip)
 		return;
 
 	auto was_available = is_available();
-	remote_host_ = std::string(ip);
+
+	if (g_strcmp0 (ip, "0.0.0.0") == 0)
+		remote_host_.clear();
+	else
+		remote_host_ = std::string(ip);
 
 	if (!observer_)
 		return;
@@ -165,7 +169,11 @@ void Peer::local_ip_changed (const char *ip)
 		return;
 
 	auto was_available = is_available();
-	local_host_ = std::string(ip);
+
+	if (g_strcmp0 (ip, "0.0.0.0") == 0)
+		local_host_.clear();
+	else
+		local_host_ = std::string(ip);
 
 	if (!observer_)
 		return;

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -30,7 +30,7 @@ namespace P2P {
 /* static C callback */
 void Peer::proxy_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
 {
-    auto client = reinterpret_cast<Peer*> (data_ptr);
+    auto client = static_cast<Peer*> (data_ptr);
     client->proxy_cb (res);
 }
 
@@ -39,7 +39,7 @@ void Peer::proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *s
 {
 	GVariant *property;
 	char *name;
-    auto peer = reinterpret_cast<Peer*> (data_ptr);
+    auto peer = static_cast<Peer*> (data_ptr);
 
     if (g_strcmp0(signal, "PropertyChanged") != 0)
         return;

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -115,6 +115,9 @@ void Peer::proxy_cb (GAsyncResult *result)
                       G_CALLBACK (Peer::proxy_signal_cb), this);
 
     /* TODO check the ip address in case it's up to date already */
+
+	if (observer_)
+		observer_->on_initialized(this);
 }
 
 void Peer::ip_changed (const char *ip)
@@ -154,6 +157,7 @@ void Peer::state_changed (bool ready)
 }
 
 Peer::Peer(const std::string& object_path, std::shared_ptr<P2P::InformationElement> ie):
+    observer_(NULL),
     ie_(ie)
 {
     g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -1,0 +1,130 @@
+/*
+ * This file is part of wysiwidi
+ *
+ * Copyright (C) 2014 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <iostream>
+#include <gio/gio.h>
+
+#include "connman-peer.h"
+
+namespace P2P {
+
+/* static C callback */
+void Peer::proxy_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
+{
+    auto client = reinterpret_cast<Peer*> (data_ptr);
+    client->proxy_cb (res);
+}
+
+/* static C callback */
+void Peer::proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr)
+{
+	GVariant *property;
+	char *name, *local, *remote;
+    auto peer = reinterpret_cast<Peer*> (data_ptr);
+
+    if (g_strcmp0(signal, "PropertyChanged") != 0)
+        return;
+
+    std::cout << "DBG: peer property changed " << std::endl;
+    g_variant_get (params, "(sv)", &name, &property);
+
+	if (g_strcmp0(name, "State") == 0) {
+	    const char *state = g_variant_get_string (property, NULL); 
+
+		peer->state_changed (g_strcmp0 (state, "ready") == 0);
+	} else if (g_strcmp0(name, "IPv4") == 0) {
+		std::cout << "DBG: peer ipv4 changed " << std::endl;
+		g_variant_get (property, "({ss})", &local, &remote);
+
+		peer->ip_changed (remote);
+	}
+}
+
+void Peer::proxy_cb (GAsyncResult *result)
+{
+    GError *error = NULL;
+
+    std::cout << "Registering proxy for peer..." << std::endl;
+
+    proxy_ = g_dbus_proxy_new_for_bus_finish(result, &error);
+    if (error) {
+        std::cout << "Peer proxy error "<< std::endl;
+        g_clear_error (&error);
+        return;
+    }
+
+    g_signal_connect (proxy_, "g-signal",
+                      G_CALLBACK (Peer::proxy_signal_cb), this);
+
+    /* TODO check the ip address in case it's up to date already */
+}
+
+void Peer::ip_changed (char *ip)
+{
+	std::string new_ip(ip);
+
+	if (new_ip.compare (ip_address_) == 0)
+		return;
+	
+	ip_address_ = new_ip;
+
+	if (ip_address_.empty() && ready_) {
+		// TODO notify observer: peer is no longer ok
+	} else if (!ip_address_.empty() && ready_) {
+		// TODO Notify observer: peer is now ok
+	}
+}
+
+void Peer::state_changed (bool ready)
+{
+	if (ready_ == ready)
+		return;
+	
+	ready_ = ready;
+
+	if (!ready_ && !ip_address_.empty())
+		// TODO Notify observer: peer is no longer ok
+	if (ready_ && !ip_address_.empty()) {
+		// TODO Notify observer: peer is now ok
+	}
+}
+
+Peer::Peer(std::string object_path, std::shared_ptr<P2P::InformationElement> ie):
+    ie_(ie)
+{
+    g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,
+                              G_DBUS_PROXY_FLAGS_NONE,
+                              NULL,
+                              "net.connman",
+                              object_path.c_str(),
+                              "net.connman.Peer",
+                              NULL,
+                              Peer::proxy_cb,
+                              this);
+}
+
+Peer::~Peer()
+{
+    if (proxy_)
+        g_clear_object (&proxy_);
+}
+
+}

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -58,6 +58,38 @@ void Peer::proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *s
 	}
 }
 
+/* static C callback */
+void Peer::connect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
+{
+    GError *error = NULL;
+    GDBusProxy *proxy = G_DBUS_PROXY (object);
+
+    g_dbus_proxy_call_finish (proxy, res, &error);
+    if (error) {
+        std::cout << "connect error " << error->message << std::endl;
+        g_clear_error (&error);
+        return;
+    }
+
+    std::cout << "* connected "<< std::endl;
+}
+
+/* static C callback */
+void Peer::disconnect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr)
+{
+    GError *error = NULL;
+    GDBusProxy *proxy = G_DBUS_PROXY (object);
+
+    g_dbus_proxy_call_finish (proxy, res, &error);
+    if (error) {
+        std::cout << "disconnect error " << error->message << std::endl;
+        g_clear_error (&error);
+        return;
+    }
+
+    std::cout << "* disconnected "<< std::endl;
+}
+
 void Peer::proxy_cb (GAsyncResult *result)
 {
     GError *error = NULL;
@@ -126,6 +158,31 @@ Peer::Peer(const std::string& object_path, std::shared_ptr<P2P::InformationEleme
                               Peer::proxy_cb,
                               this);
 }
+
+void Peer::connect()
+{
+    g_dbus_proxy_call (proxy_,
+                       "Connect",
+                       NULL,
+                       G_DBUS_CALL_FLAGS_NONE,
+                       60 * 1000, // is 1 minute too long?
+                       NULL,
+                       Peer::connect_cb,
+                       this);
+}
+
+void Peer::disconnect()
+{
+    g_dbus_proxy_call (proxy_,
+                       "Disconnect",
+                       NULL,
+                       G_DBUS_CALL_FLAGS_NONE,
+                       -1,
+                       NULL,
+                       Peer::disconnect_cb,
+                       this);
+}
+
 
 Peer::~Peer()
 {

--- a/p2p/connman-peer.cpp
+++ b/p2p/connman-peer.cpp
@@ -54,7 +54,6 @@ void Peer::proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *s
 		GVariant *spec_val;
 		char *name;
 
-		std::cout << "DBG: peer ipv4 changed " << std::endl;
 		g_variant_get (property, "a{sv}", &ips);
         while (g_variant_iter_loop (ips, "{sv}", &name, &spec_val)) {
             if (g_strcmp0 (name, "Remote") == 0) {
@@ -102,8 +101,6 @@ void Peer::proxy_cb (GAsyncResult *result)
 {
     GError *error = NULL;
 
-    std::cout << "Registering proxy for peer..." << std::endl;
-
     proxy_ = g_dbus_proxy_new_for_bus_finish(result, &error);
     if (error) {
         std::cout << "Peer proxy error "<< std::endl;
@@ -132,9 +129,7 @@ void Peer::ip_changed (const char *ip)
 	if (!observer_)
 		return;
 
-	if (ip_address_.empty() && ready_) {
-		observer_->on_state_changed(this);
-	} else if (!ip_address_.empty() && ready_) {
+	if ((ip_address_.empty() && ready_) || (!ip_address_.empty() && ready_)) {
 		observer_->on_state_changed(this);
 	}
 }
@@ -149,9 +144,7 @@ void Peer::state_changed (bool ready)
 	if (!observer_)
 		return;
 
-	if (!ready_ && !ip_address_.empty())
-		observer_->on_state_changed(this);
-	if (ready_ && !ip_address_.empty()) {
+	if ((!ready_ && !ip_address_.empty()) || (ready_ && !ip_address_.empty())) {
 		observer_->on_state_changed(this);
 	}
 }

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -51,6 +51,7 @@ class Peer {
         const std::string& remote_host() const {return remote_host_; }
         const int remote_port() const { return ie_->get_rtsp_port(); }
         const std::string& local_host() const {return local_host_; }
+        const P2P::DeviceType device_type() const { return ie_->get_device_type(); }
 	    bool is_available() const { return ready_ && !remote_host_.empty() && !local_host_.empty(); }
 
     private:

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -19,40 +19,34 @@
  * 02110-1301 USA
  */
 
-#ifndef CONNMAN_CLIENT_H_
-#define CONNMAN_CLIENT_H_
-
-#include <memory>
-#include <gio/gio.h>
-
 #include "information-element.h"
-#include "connman-peer.h"
 
-class ConnmanClient {
+#ifndef CONNMAN_PEER_H_
+#define CONNMAN_PEER_H_
+
+
+namespace P2P {
+
+class Peer {
     public:
-        ConnmanClient(std::unique_ptr<P2P::InformationElementArray> &take_array);
-        virtual ~ConnmanClient();
+        Peer(std::string object_path, std::shared_ptr<P2P::InformationElement>);
+        virtual ~Peer();
 
-        void set_information_element(std::unique_ptr<P2P::InformationElementArray> &take_array);
-		
-		// TODO scan()   (for source)
-		// TODO Observer for changes in peer list   (for source)
+		// notify of readiness changes
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
         static void proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
-        static void register_peer_service_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
 
-        void peers_changed (GVariant *params);
-        void proxy_cb(GObject *object, GAsyncResult *res);
-        void register_peer_service_cb(GObject *object, GAsyncResult *res);
+		void ip_changed (char *ip);
+		void state_changed (bool ready);
+        void proxy_cb (GAsyncResult *res);
 
-        void register_peer_service();
-        void unregister_peer_service();
-
+		std::string ip_address_;
+		bool ready_;
         GDBusProxy *proxy_;
-        std::unique_ptr<P2P::InformationElementArray>array_;
-		std::map<std::string, std::shared_ptr<P2P::Peer>> peers_;
+		std::shared_ptr<P2P::InformationElement> ie_;
 };
 
-#endif // CONNMAN_CLIENT_H_
+}
+#endif // CONNMAN_PEER_H_

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -56,7 +56,7 @@ class Peer {
         static void connect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void disconnect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
 
-		void ip_changed (char *ip);
+		void ip_changed (const char *ip);
 		void state_changed (bool ready);
         void proxy_cb (GAsyncResult *res);
 

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -32,7 +32,7 @@ class Peer {
         Peer(std::string object_path, std::shared_ptr<P2P::InformationElement>);
         virtual ~Peer();
 
-		// notify of readiness changes
+		// tODO notify observer(s) of readiness changes
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -31,6 +31,7 @@ class Peer {
 		class Observer {
 			public:
 				virtual void on_state_changed(Peer *peer) {}
+				virtual void on_initialized(Peer *peer) {}
 
 			protected:
 				virtual ~Observer() {}

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -49,6 +49,7 @@ class Peer {
 		void disconnect();
 
         const std::string& ip_address() const {return ip_address_; }
+        const int port() const { return ie_->get_rtsp_port(); }
 	    bool is_ready() const { return ready_; }
 
     private:

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -43,12 +43,18 @@ class Peer {
 			observer_ = observer;
 		}
 
+		/* TODO add error handling for these -- maybe through observer.on_error? */
+		void connect();
+		void disconnect();
+
         const std::string& ip_address() const {return ip_address_; }
 	    bool is_ready() const { return ready_; }
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
         static void proxy_cb(GObject *object, GAsyncResult *res, gpointer data_ptr);
+        static void connect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
+        static void disconnect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
 
 		void ip_changed (char *ip);
 		void state_changed (bool ready);

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -30,7 +30,7 @@ class Peer {
     public:
 		class Observer {
 			public:
-				virtual void on_state_changed(Peer *peer) {}
+				virtual void on_availability_changed(Peer *peer) {}
 				virtual void on_initialized(Peer *peer) {}
 
 			protected:
@@ -48,9 +48,10 @@ class Peer {
 		void connect();
 		void disconnect();
 
-        const std::string& ip_address() const {return ip_address_; }
-        const int port() const { return ie_->get_rtsp_port(); }
-	    bool is_available() const { return ready_ && !ip_address_.empty(); }
+        const std::string& remote_host() const {return remote_host_; }
+        const int remote_port() const { return ie_->get_rtsp_port(); }
+        const std::string& local_host() const {return local_host_; }
+	    bool is_available() const { return ready_ && !remote_host_.empty() && !local_host_.empty(); }
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
@@ -58,12 +59,14 @@ class Peer {
         static void connect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void disconnect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
 
-		void ip_changed (const char *ip);
+		void remote_ip_changed (const char *ip);
+		void local_ip_changed (const char *ip);
 		void state_changed (bool ready);
         void proxy_cb (GAsyncResult *res);
 
 		Observer *observer_;
-		std::string ip_address_;
+		std::string remote_host_;
+		std::string local_host_;
 		bool ready_;
         GDBusProxy *proxy_;
 		std::shared_ptr<P2P::InformationElement> ie_;

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -24,15 +24,27 @@
 #ifndef CONNMAN_PEER_H_
 #define CONNMAN_PEER_H_
 
-
 namespace P2P {
 
 class Peer {
     public:
-        Peer(std::string object_path, std::shared_ptr<P2P::InformationElement>);
+		class Observer {
+			public:
+				virtual void on_state_changed(Peer *peer) {}
+
+			protected:
+				virtual ~Observer() {}
+		};
+
+        Peer(const std::string& object_path, std::shared_ptr<P2P::InformationElement>);
         virtual ~Peer();
 
-		// tODO notify observer(s) of readiness changes
+		void set_observer(Observer* observer) {
+			observer_ = observer;
+		}
+
+        const std::string& ip_address() const {return ip_address_; }
+	    bool is_ready() const { return ready_; }
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);
@@ -42,6 +54,7 @@ class Peer {
 		void state_changed (bool ready);
         void proxy_cb (GAsyncResult *res);
 
+		Observer *observer_;
 		std::string ip_address_;
 		bool ready_;
         GDBusProxy *proxy_;

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -50,7 +50,7 @@ class Peer {
 
         const std::string& ip_address() const {return ip_address_; }
         const int port() const { return ie_->get_rtsp_port(); }
-	    bool is_ready() const { return ready_; }
+	    bool is_available() const { return ready_ && !ip_address_.empty(); }
 
     private:
         static void proxy_signal_cb (GDBusProxy *proxy, const char *sender, const char *signal, GVariant *params, gpointer data_ptr);

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -19,6 +19,7 @@
  * 02110-1301 USA
  */
 
+#include <gio/gio.h>
 #include "information-element.h"
 
 #ifndef CONNMAN_PEER_H_
@@ -37,7 +38,7 @@ class Peer {
 				virtual ~Observer() {}
 		};
 
-        Peer(const std::string& object_path, std::shared_ptr<P2P::InformationElement>);
+        Peer(const char *object_path, GVariantIter *property_iterator);
         virtual ~Peer();
 
 		void set_observer(Observer* observer) {
@@ -48,10 +49,11 @@ class Peer {
 		void connect();
 		void disconnect();
 
+        const P2P::DeviceType device_type() const { return ie_->get_device_type(); }
+        const std::string& name() const { return name_; }
         const std::string& remote_host() const {return remote_host_; }
         const int remote_port() const { return ie_->get_rtsp_port(); }
         const std::string& local_host() const {return local_host_; }
-        const P2P::DeviceType device_type() const { return ie_->get_device_type(); }
 	    bool is_available() const { return ready_ && !remote_host_.empty() && !local_host_.empty(); }
 
     private:
@@ -62,10 +64,13 @@ class Peer {
 
 		void remote_ip_changed (const char *ip);
 		void local_ip_changed (const char *ip);
-		void state_changed (bool ready);
+		void state_changed (const char *state);
+		void name_changed (const char *name);
         void proxy_cb (GAsyncResult *res);
+		void handle_property_change (const char *name, GVariant *property);
 
 		Observer *observer_;
+		std::string name_;
 		std::string remote_host_;
 		std::string local_host_;
 		bool ready_;

--- a/p2p/information-element.cpp
+++ b/p2p/information-element.cpp
@@ -107,6 +107,18 @@ void InformationElement::add_subelement(P2P::Subelement* subelement)
     subelements_[id] = subelement;
 }
 
+DeviceType InformationElement::get_device_type()
+{
+	auto it = subelements_.find (DEVICE_INFORMATION);
+	if (it == subelements_.end()) {
+	   /* FIXME : exception ? */
+	   return DUAL_ROLE;
+	}
+	
+	auto dev_info = (P2P::DeviceInformationSubelement*)(*it).second;
+	return (DeviceType)dev_info->field1.device_type;
+}
+
 std::unique_ptr<InformationElementArray> InformationElement::serialize () const
 {
     uint8_t pos = 0;

--- a/p2p/information-element.cpp
+++ b/p2p/information-element.cpp
@@ -107,7 +107,7 @@ void InformationElement::add_subelement(P2P::Subelement* subelement)
     subelements_[id] = subelement;
 }
 
-DeviceType InformationElement::get_device_type()
+const DeviceType InformationElement::get_device_type() const
 {
 	auto it = subelements_.find (DEVICE_INFORMATION);
 	if (it == subelements_.end()) {
@@ -117,6 +117,18 @@ DeviceType InformationElement::get_device_type()
 	
 	auto dev_info = (P2P::DeviceInformationSubelement*)(*it).second;
 	return (DeviceType)dev_info->field1.device_type;
+}
+
+const int InformationElement::get_rtsp_port() const
+{
+	auto it = subelements_.find (DEVICE_INFORMATION);
+	if (it == subelements_.end()) {
+	   /* FIXME : exception ? */
+	   return -1;
+	}
+
+	auto dev_info = (P2P::DeviceInformationSubelement*)(*it).second;
+	return dev_info->session_management_control_port;
 }
 
 std::unique_ptr<InformationElementArray> InformationElement::serialize () const

--- a/p2p/information-element.h
+++ b/p2p/information-element.h
@@ -161,6 +161,6 @@ class InformationElement {
     std::map<SubelementId, P2P::Subelement*> subelements_;
 };
 
-} // namespace wfd
+} // namespace P2P
 
 #endif // INFORMATION_ELEMENT_H_

--- a/p2p/information-element.h
+++ b/p2p/information-element.h
@@ -148,7 +148,8 @@ class InformationElement {
     virtual ~InformationElement();
 
     void add_subelement(P2P::Subelement* subelement);
-    DeviceType get_device_type();
+    const DeviceType get_device_type() const;
+    const int get_rtsp_port() const;
 
     std::unique_ptr<InformationElementArray> serialize () const;
     std::string to_string() const;

--- a/p2p/information-element.h
+++ b/p2p/information-element.h
@@ -22,6 +22,7 @@
 #ifndef INFORMATION_ELEMENT_H_
 #define INFORMATION_ELEMENT_H_
 
+#include <cstring>
 #include <map>
 #include <memory>
 #include <string>
@@ -125,6 +126,14 @@ struct InformationElementArray {
     InformationElementArray(uint len) : length(len) {
         bytes = new uint8_t[length];
     }
+
+    InformationElementArray(uint len, uint8_t* in_bytes) :
+		length(len) {
+        bytes = new uint8_t[length];
+        memcpy (bytes, in_bytes, length);
+
+	}
+
     ~InformationElementArray() {
         delete[] bytes;
     }
@@ -139,6 +148,7 @@ class InformationElement {
     virtual ~InformationElement();
 
     void add_subelement(P2P::Subelement* subelement);
+    DeviceType get_device_type();
 
     std::unique_ptr<InformationElementArray> serialize () const;
     std::string to_string() const;

--- a/p2p/main.cpp
+++ b/p2p/main.cpp
@@ -53,7 +53,7 @@ int main (int argc, const char **argv)
 
     // register the P2P service with connman
     auto array = ie.serialize ();
-    ConnmanClient client (array);
+    P2P::Client p2p_client (array);
 
     g_main_loop_run (main_loop);
     g_main_loop_unref (main_loop);

--- a/sink/CMakeLists.txt
+++ b/sink/CMakeLists.txt
@@ -18,5 +18,5 @@ include_directories(${GIO_INCLUDE_DIRS})
 pkg_check_modules (GST REQUIRED gstreamer-1.0)
 include_directories(${GST_INCLUDE_DIRS})
 
-add_executable(sink-test main.cpp sink.cpp gst_sink_media_manager.cpp)
+add_executable(sink-test main.cpp sink-app.cpp sink.cpp gst_sink_media_manager.cpp)
 target_link_libraries (sink-test mirac wysiwidi p2p ${GIO_LIBRARIES} ${GST_LIBRARIES})

--- a/sink/main.cpp
+++ b/sink/main.cpp
@@ -84,7 +84,7 @@ static gboolean _user_input_handler (
 int main (int argc, char *argv[])
 {
 	gst_init(&argc, &argv);
-	SinkApp app;
+    std::unique_ptr<SinkApp> app;
 
     GMainLoop *main_loop =  g_main_loop_new(NULL, TRUE);
     g_unix_signal_add(SIGINT, _sig_handler, main_loop);

--- a/sink/main.cpp
+++ b/sink/main.cpp
@@ -21,22 +21,13 @@
 
 #include <glib.h>
 #include <glib-unix.h>
-#include <netinet/in.h> // htons()
-#include <gst/gst.h> // gst_init_get_option_group()
+#include <gst/gst.h>
 
 #include <iostream>
 
+#include "sink-app.h"
 #include "sink.h"
-#include "connman-client.h"
 
-
-struct SinkAppData {
-    std::unique_ptr<Sink> sink;
-    std::unique_ptr<ConnmanClient> connman;
-
-    std::string host;
-    int port;
-};
 
 static gboolean _sig_handler (gpointer data_ptr)
 {
@@ -48,7 +39,7 @@ static gboolean _sig_handler (gpointer data_ptr)
 }
 
 static void parse_input_and_call_sink(
-    const std::string& command, const std::unique_ptr<Sink> &sink) {
+    const std::string& command, Sink *sink) {
     if (command == "teardown\n") {
         sink->Teardown();
         return;
@@ -70,11 +61,11 @@ static gboolean _user_input_handler (
     GError* error = NULL;
     char* str = NULL;
     size_t len;
-    SinkAppData* data = static_cast<SinkAppData*>(data_ptr);
+    SinkApp* app = static_cast<SinkApp*>(data_ptr);
 
     switch (g_io_channel_read_line(channel, &str, &len, NULL, &error)) {
     case G_IO_STATUS_NORMAL:
-        parse_input_and_call_sink(str, data->sink);
+        parse_input_and_call_sink(str, &app->sink());
         g_free(str);
         return true;
     case G_IO_STATUS_ERROR:
@@ -90,81 +81,18 @@ static gboolean _user_input_handler (
     return false;
 }
 
-static gboolean create_sink (gpointer data_ptr)
-{
-    SinkAppData* data = static_cast<SinkAppData*>(data_ptr);
-
-    try {
-        data->sink.reset(new Sink (data->host.c_str(), data->port));
-        std::cout << "Running sink on port "<< data->sink->get_host_port() << std::endl;
-        return G_SOURCE_REMOVE;
-    } catch (const std::exception &x) {
-        std::cout << "Failed to create sink, trying again soon..." << std::endl;
-        return G_SOURCE_CONTINUE;
-    }
-}
-
 int main (int argc, char *argv[])
 {
-    SinkAppData data;
-    gchar* hostname_option = NULL;
-    data.port = 7236;
-
-    GOptionEntry main_entries[] =
-    {
-        { "hostname", 0, 0, G_OPTION_ARG_STRING, &hostname_option, "Specify optional hostname, local host by default", "host"},
-        { "rtsp_port", 0, 0, G_OPTION_ARG_INT, &(data.port), "Specify optional RTSP port number, 7236 by default", "rtsp_port"},
-        { NULL }
-    };
-
-    GOptionContext* context = g_option_context_new ("- WFD sink demo application\n");
-    g_option_context_add_main_entries (context, main_entries, NULL);
-    g_option_context_add_group (context, gst_init_get_option_group ());
-
-    GError* error = NULL;
-    if (!g_option_context_parse (context, &argc, &argv, &error)) {
-        g_print ("option parsing failed: %s\n", error->message);
-        g_option_context_free(context);
-        exit (1);
-    }
-    g_option_context_free(context);
-
-    if (hostname_option) {
-        data.host = hostname_option;
-        g_free(hostname_option);
-    } else {
-        data.host ="127.0.0.1";
-    }
+	gst_init(&argc, &argv);
+	SinkApp app;
 
     GMainLoop *main_loop =  g_main_loop_new(NULL, TRUE);
     g_unix_signal_add(SIGINT, _sig_handler, main_loop);
     g_unix_signal_add(SIGTERM, _sig_handler, main_loop);
 
     GIOChannel* io_channel = g_io_channel_unix_new (STDIN_FILENO);
-    g_io_add_watch(io_channel, G_IO_IN, _user_input_handler, &data);
+    g_io_add_watch(io_channel, G_IO_IN, _user_input_handler, app.get());
     g_io_channel_unref(io_channel);
-
-    // Create a information element for a simple WFD Sink
-    P2P::InformationElement ie;
-    auto sub_element = P2P::new_subelement(P2P::DEVICE_INFORMATION);
-    auto dev_info = (P2P::DeviceInformationSubelement*)sub_element;
-    // FIXME port number is a lie
-    dev_info->session_management_control_port =  htons(7236);
-    dev_info->maximum_throughput = htons(50);
-    dev_info->field1.device_type = P2P::PRIMARY_SINK;
-    dev_info->field1.session_availability = true;
-    ie.add_subelement (sub_element);
-
-    std::cout << "Registering Wifi Display on port with IE " << ie.to_string() <<  std::endl;
-
-    // register the P2P service with connman
-    auto array = ie.serialize ();
-    data.connman.reset(new ConnmanClient (array));
-
-    // Hack while we wait for a better solution:
-    // try to create a sink every second and hope the connect succeeds at some point
-    // when the source is actually there...
-    g_timeout_add_seconds (1, create_sink, &data);
 
     g_main_loop_run (main_loop);
 

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -35,9 +35,9 @@ void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> pe
 void SinkApp::on_state_changed(P2P::Peer *peer)
 {
 	/* TODO only observe sources ... */
-	if (peer->is_ready()) {
+	if (peer->is_available()) {
 		std::cout << "* Connecting to peer at " << peer->ip_address() << ":" << ntohs(peer->port()) << std::endl;
-		
+
         sink_.reset(new Sink (peer->ip_address(), ntohs(peer->port())));
 	}
 }

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -26,7 +26,7 @@
 #include "sink.h"
 #include "connman-client.h"
 
-void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer)
+void SinkApp::on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer)
 {
 	std::cout << "* New peer: " << peer->name() << std::endl;
 	peer->set_observer (this);
@@ -61,7 +61,7 @@ SinkApp::SinkApp(){
 
     // register the P2P service with connman
     auto array = ie.serialize ();
-    connman_.reset(new ConnmanClient (array, this));
+    p2p_client_.reset(new P2P::Client(array, this));
 }
 
 SinkApp::SinkApp(const std::string& hostname, int port)

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -1,0 +1,71 @@
+/*
+ * This file is part of wysiwidi
+ *
+ * Copyright (C) 2014 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <iostream>
+#include <netinet/in.h> // htons()
+
+#include "sink-app.h"
+#include "sink.h"
+#include "connman-client.h"
+
+void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer)
+{
+	std::cout << "* New peer" << std::endl;
+	peer->set_observer (this);
+}
+
+void SinkApp::on_state_changed(P2P::Peer *peer)
+{
+	/* TODO only observe sources ... */
+	if (peer->is_ready()) {
+		std::cout << "* Connecting to peer at " << peer->ip_address() << ":" << ntohs(peer->port()) << std::endl;
+		
+        sink_.reset(new Sink (peer->ip_address(), ntohs(peer->port())));
+	}
+}
+
+SinkApp::SinkApp(){
+
+    // Create a information element for a simple WFD Sink
+    P2P::InformationElement ie;
+    auto sub_element = P2P::new_subelement(P2P::DEVICE_INFORMATION);
+    auto dev_info = (P2P::DeviceInformationSubelement*)sub_element;
+
+    // TODO port number is a lie -- we should start the sink first, then 
+    // use the port from there (and sink should probably default to 7236)
+
+	// TODO InformationElement could have constructors for this stuff...
+    dev_info->session_management_control_port = htons(7236);
+    dev_info->maximum_throughput = htons(50);
+    dev_info->field1.device_type = P2P::PRIMARY_SINK;
+    dev_info->field1.session_availability = true;
+    ie.add_subelement (sub_element);
+
+    std::cout << "* Registering Wifi Display with IE " << ie.to_string() <<  std::endl;
+
+    // register the P2P service with connman
+    auto array = ie.serialize ();
+    connman_.reset(new ConnmanClient (array, this));
+}
+
+SinkApp::~SinkApp() {
+	
+}

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -32,13 +32,13 @@ void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> pe
 	peer->set_observer (this);
 }
 
-void SinkApp::on_state_changed(P2P::Peer *peer)
+void SinkApp::on_availability_changed(P2P::Peer *peer)
 {
 	/* TODO only observe sources ... */
 	if (peer->is_available()) {
-		std::cout << "* Connecting to peer at " << peer->ip_address() << ":" << ntohs(peer->port()) << std::endl;
+		std::cout << "* Connecting to peer at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
 
-        sink_.reset(new Sink (peer->ip_address(), ntohs(peer->port())));
+        sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port())));
 	}
 }
 

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -43,7 +43,6 @@ void SinkApp::on_availability_changed(P2P::Peer *peer)
 }
 
 SinkApp::SinkApp(){
-
     // Create a information element for a simple WFD Sink
     P2P::InformationElement ie;
     auto sub_element = P2P::new_subelement(P2P::DEVICE_INFORMATION);
@@ -64,6 +63,13 @@ SinkApp::SinkApp(){
     // register the P2P service with connman
     auto array = ie.serialize ();
     connman_.reset(new ConnmanClient (array, this));
+}
+
+SinkApp::SinkApp(const std::string& hostname, int port)
+{
+    std::cout << "* Connecting to peer at " << hostname << ":" << port << std::endl;
+
+    sink_.reset(new Sink (hostname, port, ""));
 }
 
 SinkApp::~SinkApp() {

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -28,7 +28,7 @@
 
 void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer)
 {
-	std::cout << "* New peer" << std::endl;
+	std::cout << "* New peer: " << peer->name() << std::endl;
 	peer->set_observer (this);
 }
 

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -34,12 +34,11 @@ void SinkApp::on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> pe
 
 void SinkApp::on_availability_changed(P2P::Peer *peer)
 {
-	/* TODO only observe sources ... */
-	if (peer->is_available()) {
-		std::cout << "* Connecting to peer at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
+    if (!sink_ && peer->is_available() && peer->device_type() == P2P::SOURCE) {
+        std::cout << "* Connecting to source at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
 
         sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port()), peer->local_host()));
-	}
+    }
 }
 
 SinkApp::SinkApp(){

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -38,7 +38,7 @@ void SinkApp::on_availability_changed(P2P::Peer *peer)
 	if (peer->is_available()) {
 		std::cout << "* Connecting to peer at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
 
-        sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port())));
+        sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port()), peer->local_host()));
 	}
 }
 

--- a/sink/sink-app.h
+++ b/sink/sink-app.h
@@ -30,6 +30,7 @@
 class SinkApp: public ConnmanClient::Observer, public P2P::Peer::Observer {
 	public:
 		SinkApp();
+		SinkApp(const std::string& hostname, int port);
 		~SinkApp();
 
 		Sink& sink() { return *sink_; }

--- a/sink/sink-app.h
+++ b/sink/sink-app.h
@@ -37,7 +37,7 @@ class SinkApp: public ConnmanClient::Observer, public P2P::Peer::Observer {
 		void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) override;
 		void on_initialized(ConnmanClient *client)  override {};
 		
-		void on_state_changed(P2P::Peer *peer) override;
+		void on_availability_changed(P2P::Peer *peer) override;
 		void on_initialized(P2P::Peer *peer) override {};
 
 	private:

--- a/sink/sink-app.h
+++ b/sink/sink-app.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of wysiwidi
+ *
+ * Copyright (C) 2014 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef SINK_APP_H
+#define SINK_APP_H
+
+#include <memory>
+
+#include "sink.h"
+#include "connman-client.h"
+
+class SinkApp: public ConnmanClient::Observer, public P2P::Peer::Observer {
+	public:
+		SinkApp();
+		~SinkApp();
+
+		Sink& sink() { return *sink_; }
+
+		void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) override;
+		void on_initialized(ConnmanClient *client)  override {};
+		
+		void on_state_changed(P2P::Peer *peer) override;
+		void on_initialized(P2P::Peer *peer) override {};
+
+	private:
+		std::unique_ptr<ConnmanClient> connman_;
+		std::unique_ptr<Sink> sink_;
+};
+
+#endif // SINK_APP_H

--- a/sink/sink-app.h
+++ b/sink/sink-app.h
@@ -27,7 +27,7 @@
 #include "sink.h"
 #include "connman-client.h"
 
-class SinkApp: public ConnmanClient::Observer, public P2P::Peer::Observer {
+class SinkApp: public P2P::Client::Observer, public P2P::Peer::Observer {
 	public:
 		SinkApp();
 		SinkApp(const std::string& hostname, int port);
@@ -35,14 +35,14 @@ class SinkApp: public ConnmanClient::Observer, public P2P::Peer::Observer {
 
 		Sink& sink() { return *sink_; }
 
-		void on_peer_added(ConnmanClient *client, std::shared_ptr<P2P::Peer> peer) override;
-		void on_initialized(ConnmanClient *client)  override {};
+		void on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer) override;
+		void on_initialized(P2P::Client *client) override {};
 		
 		void on_availability_changed(P2P::Peer *peer) override;
 		void on_initialized(P2P::Peer *peer) override {};
 
 	private:
-		std::unique_ptr<ConnmanClient> connman_;
+		std::unique_ptr<P2P::Client> p2p_client_;
 		std::unique_ptr<Sink> sink_;
 };
 

--- a/sink/sink.cpp
+++ b/sink/sink.cpp
@@ -22,8 +22,9 @@
 #include "sink.h"
 #include "gst_sink_media_manager.h"
 
-Sink::Sink(const std::string& host, int rtsp_port)
-  : MiracBroker(host.c_str(), std::to_string(rtsp_port)) {
+Sink::Sink(const std::string& remote_host, int remote_rtsp_port, const std::string& local_host)
+  : MiracBroker(remote_host, std::to_string(remote_rtsp_port)),
+    local_host_(local_host) {
 }
 
 Sink::~Sink() {}
@@ -33,7 +34,7 @@ void Sink::got_message(const std::string& message) {
 }
 
 void Sink::on_connected() {
-  media_manager_.reset(new GstSinkMediaManager(get_peer_address()));
+  media_manager_.reset(new GstSinkMediaManager(local_host_));
   wfd_sink_.reset(wfd::Sink::Create(this, media_manager_.get()));
   wfd_sink_->Start();
 }

--- a/sink/sink.h
+++ b/sink/sink.h
@@ -31,7 +31,7 @@
 
 class Sink : public MiracBroker {
  public:
-  explicit Sink(const std::string& host, int rtsp_port);
+  explicit Sink(const std::string& remote_host, int remote_rtsp_port, const std::string& local_host);
   ~Sink();
 
   void Play();
@@ -47,6 +47,7 @@ class Sink : public MiracBroker {
 
   std::unique_ptr<wfd::SinkMediaManager> media_manager_;
   std::unique_ptr<wfd::Sink> wfd_sink_;
+  std::string local_host_;
 };
 
 #endif // SINK_H


### PR DESCRIPTION
Okay, it's a pretty big patchset that exposes a Miracast-specific subset of P2P API provided by connman. It also includes the changes required in sink to use this stuff.

Here come the excuses:

* All the other commits could be squashed to a single "Implement P2P api" commit -- and this is how I would review this myself: they all either add new functionality in p2p/ or use that functionality in sink/

EDIT: removed the whitespace fixes: please assume I'll fix the weird tab/space combinations in a later patch.