### PR TITLE
network: Add connect retry ability to Broker

### DIFF
--- a/mirac_network/mirac-broker.cpp
+++ b/mirac_network/mirac-broker.cpp
@@ -34,35 +34,35 @@ struct TimerCallbackData {
 /* static C callback wrapper */
 gboolean MiracBroker::send_cb (gint fd, GIOCondition condition, gpointer data_ptr)
 {
-    auto broker = reinterpret_cast<MiracBroker*> (data_ptr);
+    auto broker = static_cast<MiracBroker*> (data_ptr);
     return broker->send_cb(fd, condition);
 }
 
 /* static C callback wrapper */
 gboolean MiracBroker::receive_cb (gint fd, GIOCondition condition, gpointer data_ptr)
 {
-    auto broker = reinterpret_cast<MiracBroker*> (data_ptr);
+    auto broker = static_cast<MiracBroker*> (data_ptr);
     return broker->receive_cb(fd, condition);
 }
 
 /* static C callback wrapper */
 gboolean MiracBroker::listen_cb (gint fd, GIOCondition condition, gpointer data_ptr)
 {
-    auto broker = reinterpret_cast<MiracBroker*> (data_ptr);
+    auto broker = static_cast<MiracBroker*> (data_ptr);
     return broker->listen_cb(fd, condition);
 }
 
 /* static C callback wrapper */
 gboolean MiracBroker::connect_cb (gint fd, GIOCondition condition, gpointer data_ptr)
 {
-    auto broker = reinterpret_cast<MiracBroker*> (data_ptr);
+    auto broker = static_cast<MiracBroker*> (data_ptr);
     return broker->connect_cb(fd, condition);
 }
 
 /* static C callback wrapper */
 gboolean MiracBroker::try_connect (gpointer data_ptr)
 {
-    auto broker = reinterpret_cast<MiracBroker*> (data_ptr);
+    auto broker = static_cast<MiracBroker*> (data_ptr);
     broker->try_connect();
     return false;
 }

--- a/mirac_network/mirac-broker.hpp
+++ b/mirac_network/mirac-broker.hpp
@@ -41,7 +41,7 @@ class MiracBroker : public wfd::Peer::Delegate
 {
     public:
         MiracBroker (const std::string& listen_port);
-        MiracBroker(const std::string& peer_address, const std::string& peer_port);
+        MiracBroker(const std::string& peer_address, const std::string& peer_port, uint timeout = 2000);
         virtual ~MiracBroker ();
         unsigned short get_host_port() const;
         std::string get_peer_address() const;
@@ -56,17 +56,20 @@ class MiracBroker : public wfd::Peer::Delegate
 
         virtual void got_message(const std::string& data) {}
         virtual void on_connected() {};
+        virtual void on_connect_timeout() {};
 
     private:
         static gboolean send_cb (gint fd, GIOCondition condition, gpointer data_ptr);
         static gboolean receive_cb (gint fd, GIOCondition condition, gpointer data_ptr);
         static gboolean listen_cb (gint fd, GIOCondition condition, gpointer data_ptr);
         static gboolean connect_cb (gint fd, GIOCondition condition, gpointer data_ptr);
+        static gboolean try_connect(gpointer data_ptr);
 
         gboolean send_cb (gint fd, GIOCondition condition);
         gboolean receive_cb (gint fd, GIOCondition condition);
         gboolean listen_cb (gint fd, GIOCondition condition);
         gboolean connect_cb (gint fd, GIOCondition condition);
+        void try_connect();
 
         void handle_body(const std::string msg);
         void handle_header(const std::string msg);
@@ -74,6 +77,14 @@ class MiracBroker : public wfd::Peer::Delegate
         std::unique_ptr<MiracNetwork> network_;
         std::unique_ptr<MiracNetwork> connection_;
         std::vector<uint> timers_;
+
+        std::string peer_address_;
+        std::string peer_port_;
+
+        GTimer *connect_timer_;
+        uint connect_wait_id_;
+        uint connect_timeout_;
+        static const uint connect_wait_ = 200;
 };
 
 


### PR DESCRIPTION
The peer might not be ready to accept a connection by the time we
try to Connect(): try periodically again until connection succeeds
or a timeout is reached.

The timeout is modifiable (default is 2 seconds) but the wait between retries is currently not (200ms).

I've tested this with Android and it fixes a real problem: the first connect often fails as if the peer was unavailable but trying again after a short while works.