### PR TITLE
desktop_source: Use new p2p API

### DIFF
--- a/desktop_source/CMakeLists.txt
+++ b/desktop_source/CMakeLists.txt
@@ -20,5 +20,5 @@ include_directories(${GIO_INCLUDE_DIRS})
 pkg_check_modules (GST REQUIRED gstreamer-1.0)
 include_directories(${GST_INCLUDE_DIRS})
 
-add_executable(desktop-source-test main.cpp mirac_broker_source.cpp desktop_media_manager.cpp)
+add_executable(desktop-source-test main.cpp source-app.cpp mirac_broker_source.cpp desktop_media_manager.cpp)
 target_link_libraries (desktop-source-test  mirac wysiwidi p2p ${GIO_LIBRARIES} ${GST_LIBRARIES})

--- a/desktop_source/main.cpp
+++ b/desktop_source/main.cpp
@@ -21,22 +21,13 @@
 
 #include <glib.h>
 #include <glib-unix.h>
-#include <netinet/in.h> // htons()
+#include <gst/gst.h>
 #include <iostream>
 
+#include "source-app.h"
 #include "mirac_broker_source.h"
-#include "mirac-gst-test-source.hpp"
-
-#include "connman-client.h"
 
 #include "wfd/public/source.h"
-
-struct SourceAppData {
-    std::unique_ptr<MiracBrokerSource> source;
-    std::unique_ptr<P2P::Client> p2p_client;
-
-    int port;
-};
 
 static gboolean _sig_handler (gpointer data_ptr)
 {
@@ -48,19 +39,27 @@ static gboolean _sig_handler (gpointer data_ptr)
 }
 
 static void parse_input_and_call_source(
-    const std::string& command, const std::unique_ptr<MiracBrokerSource> &source) {
+    const std::string& command, SourceApp *app) {
+
+    auto source = app->source()->wfd_source();
     bool status = true;
-    if (command == "teardown\n") {
-      status = source->wfd_source()->Teardown();
+
+    if (command == "scan\n") {
+        app->scan();
+    } else if (command.find("connect ") == 0) {
+        app->connect(std::stoi(command.substr(8)));
+    } else if (command == "teardown\n") {
+        status = source && source->Teardown();
     } else if (command == "pause\n") {
-      status = source->wfd_source()->Pause();
+        status = source && source->Pause();
     } else if (command == "play\n") {
-      status = source->wfd_source()->Play();
+        status = source && source->Play();
     } else {
-      std::cout << "Received unknown command: " << command << std::endl;
+        std::cout << "Received unknown command: " << command << std::endl;
     }
+
     if (!status)
-      std::cout << "This command cannot be executed now." << std::endl;
+        std::cout << "This command cannot be executed now." << std::endl;
 }
 
 static gboolean _user_input_handler (
@@ -69,11 +68,11 @@ static gboolean _user_input_handler (
     GError* error = NULL;
     char* str = NULL;
     size_t len;
-    SourceAppData* data = static_cast<SourceAppData*>(data_ptr);
+    SourceApp* app = static_cast<SourceApp*>(data_ptr);
 
     switch (g_io_channel_read_line(channel, &str, &len, NULL, &error)) {
     case G_IO_STATUS_NORMAL:
-        parse_input_and_call_source(str, data->source);
+        parse_input_and_call_source(str, app);
         g_free(str);
         return true;
     case G_IO_STATUS_ERROR:
@@ -91,12 +90,11 @@ static gboolean _user_input_handler (
 
 int main (int argc, char *argv[])
 {
-    SourceAppData data;
-    data.port = 7236;
+    int port = 7236;
 
     GOptionEntry main_entries[] =
     {
-        { "rtsp_port", 0, 0, G_OPTION_ARG_INT, &(data.port), "Specify optional RTSP port number, 7236 by default", "rtsp_port"},
+        { "rtsp_port", 0, 0, G_OPTION_ARG_INT, &(port), "Specify optional RTSP port number, 7236 by default", "rtsp_port"},
         { NULL }
     };
 
@@ -112,32 +110,17 @@ int main (int argc, char *argv[])
     }
     g_option_context_free(context);
 
+    SourceApp app(port);
+
     GMainLoop *main_loop =  g_main_loop_new(NULL, TRUE);
     g_unix_signal_add(SIGINT, _sig_handler, main_loop);
     g_unix_signal_add(SIGTERM, _sig_handler, main_loop);
 
     GIOChannel* io_channel = g_io_channel_unix_new (STDIN_FILENO);
-    g_io_add_watch(io_channel, G_IO_IN, _user_input_handler, &data);
+    g_io_add_watch(io_channel, G_IO_IN, _user_input_handler, &app);
     g_io_channel_unref(io_channel);
 
-    // Create a information element for a simple WFD Source
-    // FIXME: is this correct? maybe we're supposed to actively scan for
-    // WFD sinks instead
-    P2P::InformationElement ie;
-    auto sub_element = P2P::new_subelement(P2P::DEVICE_INFORMATION);
-    auto dev_info = (P2P::DeviceInformationSubelement*)sub_element;
-    dev_info->session_management_control_port =  htons(data.port);
-    dev_info->maximum_throughput = htons(50);
-    dev_info->field1.device_type = P2P::SOURCE;
-    dev_info->field1.session_availability = true;
-    ie.add_subelement (sub_element);
 
-    std::cout << "Registering Wifi Source on port with IE " << ie.to_string() <<  std::endl;
-
-    // register the P2P service with connman
-    auto array = ie.serialize ();
-    data.p2p_client.reset(new P2P::Client (array));
-    data.source.reset(new MiracBrokerSource(data.port));
     g_main_loop_run (main_loop);
 
     g_main_loop_unref (main_loop);

--- a/desktop_source/source-app.cpp
+++ b/desktop_source/source-app.cpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of wysiwidi
+ *
+ * Copyright (C) 2014 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include <iostream>
+#include <netinet/in.h> // htons()
+
+#include "source-app.h"
+
+void SourceApp::on_initialized(P2P::Client *client)
+{
+    scan();
+}
+
+void SourceApp::on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer)
+{
+    if (peer->device_type() == P2P::PRIMARY_SINK) {
+        peer->set_observer(this);
+    }
+}
+
+void SourceApp::on_peer_removed(P2P::Client *client, std::shared_ptr<P2P::Peer> peer)
+{
+    for (auto it = peers_.begin(); it != peers_.end();) {
+        if (it->second == peer.get()) {
+            peers_.erase (it++);
+            return;
+        } else {
+            ++it;
+        }
+    }
+}
+
+void SourceApp::on_initialized(P2P::Peer *peer)
+{
+    peers_[peer_index_] = peer;
+    std::cout << "  "<< peer_index_ << " : " << peer->name() << std::endl;
+    peer_index_++;
+}
+
+void SourceApp::scan()
+{
+    std::cout << "* Now scanning for peers..." << std::endl;
+    p2p_client_->scan();
+}
+
+bool SourceApp::connect(uint peer_index)
+{
+    auto it = peers_.find (peer_index);
+    if (it == peers_.end()) {
+        std::cout << "No such peer" << std::endl;
+        return false;
+    }
+
+    it->second->connect ();
+    return true;
+}
+
+void SourceApp::on_availability_changed(P2P::Peer *peer)
+{
+    if (!peer->is_available())
+        return;
+
+    std::cout << "* Connected to " << peer->remote_host()  << std::endl;
+}
+
+SourceApp::SourceApp(int port) :
+    peer_index_(0)
+{
+    // Create a information element for a simple WFD Source
+    P2P::InformationElement ie;
+    auto sub_element = P2P::new_subelement(P2P::DEVICE_INFORMATION);
+    auto dev_info = (P2P::DeviceInformationSubelement*)sub_element;
+
+    // TODO InformationElement could have constructors for this stuff...
+    dev_info->session_management_control_port = htons(port);
+    dev_info->maximum_throughput = htons(50);
+    dev_info->field1.device_type = P2P::SOURCE;
+    dev_info->field1.session_availability = true;
+    ie.add_subelement(sub_element);
+
+    std::cout << "* Registering Wi-Fi Display Source with IE " << ie.to_string() <<  std::endl;
+
+    // register the P2P service with connman
+    auto array = ie.serialize ();
+    p2p_client_.reset(new P2P::Client(array, this));
+
+    source_.reset(new MiracBrokerSource(port));
+}
+
+SourceApp::~SourceApp()
+{
+}

--- a/desktop_source/source-app.h
+++ b/desktop_source/source-app.h
@@ -1,0 +1,55 @@
+/*
+ * This file is part of wysiwidi
+ *
+ * Copyright (C) 2014 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef SOURCE_APP_H
+#define SOURCE_APP_H
+
+#include <memory>
+
+#include "source.h"
+#include "connman-client.h"
+#include "mirac_broker_source.h"
+
+class SourceApp: public P2P::Client::Observer, public P2P::Peer::Observer {
+  public:
+    SourceApp(int port);
+    ~SourceApp();
+
+    MiracBrokerSource* source() { return source_.get(); }
+
+    void on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer) override;
+    void on_peer_removed(P2P::Client *client, std::shared_ptr<P2P::Peer> peer) override;
+    void on_initialized(P2P::Client *client) override;
+
+    void on_availability_changed(P2P::Peer *peer) override;
+    void on_initialized(P2P::Peer *peer) override;
+
+    void scan();
+    bool connect(uint peer_index);
+
+  private:
+    std::unique_ptr<P2P::Client> p2p_client_;
+    std::unique_ptr<MiracBrokerSource> source_;
+    std::map<uint, P2P::Peer*>peers_;
+    uint peer_index_;
+};
+
+#endif // SOURCE_APP_H


### PR DESCRIPTION
This adds a couple of commands to desktop_source:
  scan             -- scans for Miracast sinks
  connect <index>  -- connects to a sink
On startup a scan is initiated automatically.

When a new sink is seen (typically because of a scan),
a sink index and the name of the device are printed.