### PR TITLE
Do not use 'virtual' when 'override' is used.

### DIFF
--- a/wfd/common/message_handler.cpp
+++ b/wfd/common/message_handler.cpp
@@ -244,7 +244,7 @@ void MessageReceiverBase::Handle(std::unique_ptr<Message> message) {
     return;
   }
   reply->header().set_cseq(message->cseq());
-  sender_->SendRTSPData(reply->to_string());
+  sender_->SendRTSPData(reply->ToString());
   observer_->OnCompleted(shared_from_this());
 }
 
@@ -272,7 +272,7 @@ void MessageSenderBase::Send(std::unique_ptr<Message> message) {
   }
   parcel_queue_.push_front(
       {message->cseq(), sender_->CreateTimer(GetResponseTimeout())});
-  sender_->SendRTSPData(message->to_string());
+  sender_->SendRTSPData(message->ToString());
 }
 
 bool MessageSenderBase::CanHandle(Message* message) const {

--- a/wfd/common/message_handler.h
+++ b/wfd/common/message_handler.h
@@ -105,23 +105,23 @@ class MessageSequenceHandler : public MessageHandler,
                                public MessageHandler::Observer {
  public:
   explicit MessageSequenceHandler(const InitParams& init_params);
-  virtual ~MessageSequenceHandler();
-  virtual void Start() override;
-  virtual void Reset() override;
+  ~MessageSequenceHandler() override;
+  void Start() override;
+  void Reset() override;
 
-  virtual bool CanSend(Message* message) const override;
-  virtual void Send(std::unique_ptr<Message> message) override;
+  bool CanSend(Message* message) const override;
+  void Send(std::unique_ptr<Message> message) override;
 
-  virtual bool CanHandle(Message* message) const override;
-  virtual void Handle(std::unique_ptr<Message> message) override;
+  bool CanHandle(Message* message) const override;
+  void Handle(std::unique_ptr<Message> message) override;
 
-  virtual bool HandleTimeoutEvent(uint timer_id) const override;
+  bool HandleTimeoutEvent(uint timer_id) const override;
 
  protected:
   void AddSequencedHandler(MessageHandlerPtr handler);
   // MessageHandler::Observer implementation.
-  virtual void OnCompleted(MessageHandlerPtr handler) override;
-  virtual void OnError(MessageHandlerPtr handler) override;
+  void OnCompleted(MessageHandlerPtr handler) override;
+  void OnError(MessageHandlerPtr handler) override;
 
   std::vector<MessageHandlerPtr> handlers_;
   MessageHandlerPtr current_handler_;
@@ -130,21 +130,21 @@ class MessageSequenceHandler : public MessageHandler,
 class MessageSequenceWithOptionalSetHandler : public MessageSequenceHandler {
  public:
   explicit MessageSequenceWithOptionalSetHandler(const InitParams& init_params);
-  virtual ~MessageSequenceWithOptionalSetHandler();
-  virtual void Start() override;
-  virtual void Reset() override;
-  virtual bool CanSend(Message* message) const override;
-  virtual void Send(std::unique_ptr<Message> message) override;
-  virtual bool CanHandle(Message* message) const override;
-  virtual void Handle(std::unique_ptr<Message> message) override;
+  ~MessageSequenceWithOptionalSetHandler() override;
+  void Start() override;
+  void Reset() override;
+  bool CanSend(Message* message) const override;
+  void Send(std::unique_ptr<Message> message) override;
+  bool CanHandle(Message* message) const override;
+  void Handle(std::unique_ptr<Message> message) override;
 
-  virtual bool HandleTimeoutEvent(uint timer_id) const override;
+  bool HandleTimeoutEvent(uint timer_id) const override;
 
  protected:
   void AddOptionalHandler(MessageHandlerPtr handler);
   // MessageHandler::Observer implementation.
-  virtual void OnCompleted(MessageHandlerPtr handler) override;
-  virtual void OnError(MessageHandlerPtr handler) override;
+  void OnCompleted(MessageHandlerPtr handler) override;
+  void OnError(MessageHandlerPtr handler) override;
 
   std::vector<MessageHandlerPtr> optional_handlers_;
 };
@@ -160,18 +160,18 @@ class MessageSequenceWithOptionalSetHandler : public MessageSequenceHandler {
 class MessageReceiverBase : public MessageHandler {
  public:
   explicit MessageReceiverBase(const InitParams& init_params);
-  virtual ~MessageReceiverBase();
+  ~MessageReceiverBase() override;
 
  protected:
   virtual std::unique_ptr<wfd::Reply> HandleMessage(Message* message) = 0;
-  virtual bool CanHandle(Message* message) const override;
-  virtual void Handle(std::unique_ptr<Message> message) override;
+  bool CanHandle(Message* message) const override;
+  void Handle(std::unique_ptr<Message> message) override;
 
  private:
-  virtual void Start() override;
-  virtual void Reset() override;
-  virtual bool CanSend(Message* message) const override;
-  virtual void Send(std::unique_ptr<Message> message) override;
+  void Start() override;
+  void Reset() override;
+  bool CanSend(Message* message) const override;
+  void Send(std::unique_ptr<Message> message) override;
 
   bool wait_for_message_;
 };
@@ -182,7 +182,7 @@ class MessageReceiver : public MessageReceiverBase {
   using MessageReceiverBase::MessageReceiverBase;
 
  protected:
-  virtual bool CanHandle(Message* message) const override {
+  bool CanHandle(Message* message) const override {
     return MessageReceiverBase::CanHandle(message) && message->is_request() &&
            id == ToRequest(message)->id();
   }
@@ -191,18 +191,18 @@ class MessageReceiver : public MessageReceiverBase {
 class MessageSenderBase : public MessageHandler {
  public:
   explicit MessageSenderBase(const InitParams& init_params);
-  virtual ~MessageSenderBase();
+  ~MessageSenderBase() override;
 
  protected:
   virtual bool HandleReply(Reply* reply) = 0;
-  virtual void Send(std::unique_ptr<Message> message) override;
-  virtual void Reset() override;
-  virtual bool HandleTimeoutEvent(uint timer_id) const override;
+  void Send(std::unique_ptr<Message> message) override;
+  void Reset() override;
+  bool HandleTimeoutEvent(uint timer_id) const override;
 
 
  private:
-  virtual bool CanHandle(Message* message) const override;
-  virtual void Handle(std::unique_ptr<Message> message) override;
+  bool CanHandle(Message* message) const override;
+  void Handle(std::unique_ptr<Message> message) override;
 
   virtual int GetResponseTimeout() const;
 
@@ -219,31 +219,29 @@ class OptionalMessageSender : public MessageSenderBase {
  public:
   using MessageSenderBase::MessageSenderBase;
 
-  virtual ~OptionalMessageSender() {}
-
  protected:
-  virtual bool CanSend(Message* message) const override {
+  bool CanSend(Message* message) const override {
     assert(message);
     return message->is_request() && ToRequest(message)->id() == id;
   }
 
  private:
-  virtual void Start() override {}
+  void Start() override {}
 };
 
 // To be used for sequensed senders.
 class SequencedMessageSender : public MessageSenderBase {
  public:
   explicit SequencedMessageSender(const InitParams& init_params);
-  virtual ~SequencedMessageSender();
+  ~SequencedMessageSender() override;
 
  protected:
   virtual std::unique_ptr<Message> CreateMessage() = 0;
 
  private:
-  virtual void Start() override;
-  virtual void Reset() override;
-  virtual bool CanSend(Message* message) const override;
+  void Start() override;
+  void Reset() override;
+  bool CanSend(Message* message) const override;
 
   Message* to_be_send_;
 };

--- a/wfd/parser/audiocodecs.cpp
+++ b/wfd/parser/audiocodecs.cpp
@@ -65,7 +65,7 @@ void AudioCodec::set_latency(unsigned short latency) {
   latency_ = latency;
 }
 
-std::string AudioCodec::to_string() const {
+std::string AudioCodec::ToString() const {
   MAKE_HEX_STRING_8(audio_modes_str,
       static_cast<unsigned int>(audio_modes().to_ulong()));
   MAKE_HEX_STRING_2(latency_str, latency());
@@ -86,7 +86,7 @@ AudioCodecs::AudioCodecs(const std::vector<AudioCodec>& audio_codecs)
 AudioCodecs::~AudioCodecs() {
 }
 
-std::string AudioCodecs::to_string() const {
+std::string AudioCodecs::ToString() const {
   std::string ret = PropertyName::wfd_audio_codecs + std::string(SEMICOLON)
     + std::string(SPACE);
 
@@ -94,7 +94,7 @@ std::string AudioCodecs::to_string() const {
     auto i = audio_codecs_.begin();
     auto end = audio_codecs_.end();
     while (i != end) {
-      ret += (*i).to_string();
+      ret += (*i).ToString();
       if (i != --audio_codecs_.end()) {
         ret += ", ";
       }

--- a/wfd/parser/audiocodecs.h
+++ b/wfd/parser/audiocodecs.h
@@ -63,7 +63,7 @@ struct AudioCodec {
   unsigned short latency() const;
   void set_latency(unsigned short latency);
 
-  std::string to_string() const;
+  std::string ToString() const;
 
  private:
   AudioFormat::Type audio_format_;
@@ -75,10 +75,10 @@ class AudioCodecs: public Property {
  public:
   AudioCodecs();
   AudioCodecs(const std::vector<AudioCodec>& audio_codecs);
-  virtual ~AudioCodecs();
+  ~AudioCodecs() override;
 
   const std::vector<AudioCodec>& audio_codecs() const { return audio_codecs_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   std::vector<AudioCodec> audio_codecs_;

--- a/wfd/parser/avformatchangetiming.cpp
+++ b/wfd/parser/avformatchangetiming.cpp
@@ -37,7 +37,7 @@ AVFormatChangeTiming::AVFormatChangeTiming(unsigned long long int pts,
 AVFormatChangeTiming::~AVFormatChangeTiming() {
 }
 
-std::string AVFormatChangeTiming::to_string() const {
+std::string AVFormatChangeTiming::ToString() const {
   MAKE_HEX_STRING_10(pts, pts_);
   MAKE_HEX_STRING_10(dts, dts_);
   std::string ret =

--- a/wfd/parser/avformatchangetiming.h
+++ b/wfd/parser/avformatchangetiming.h
@@ -30,12 +30,12 @@ namespace wfd {
 class AVFormatChangeTiming: public Property {
 public:
   AVFormatChangeTiming(unsigned long long int pts, unsigned long long int dts);
-  virtual ~AVFormatChangeTiming();
+  ~AVFormatChangeTiming() override;
 
   unsigned long long int pts() const { return pts_; }
   unsigned long long int dts() const { return dts_; }
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned long long int pts_;

--- a/wfd/parser/clientrtpports.cpp
+++ b/wfd/parser/clientrtpports.cpp
@@ -39,7 +39,7 @@ ClientRtpPorts::ClientRtpPorts(unsigned short rtp_port_0,
 ClientRtpPorts::~ClientRtpPorts() {
 }
 
-std::string ClientRtpPorts::to_string() const {
+std::string ClientRtpPorts::ToString() const {
   std::string ret = PropertyName::wfd_client_rtp_ports + std::string(SEMICOLON)
     + std::string(SPACE) + profile
     + std::string(SPACE) + std::to_string(rtp_port_0_)

--- a/wfd/parser/clientrtpports.h
+++ b/wfd/parser/clientrtpports.h
@@ -30,11 +30,11 @@ namespace wfd {
 class ClientRtpPorts: public Property {
  public:
   ClientRtpPorts(unsigned short rtp_port_0, unsigned short rtp_port_1);
-  virtual ~ClientRtpPorts();
+  ~ClientRtpPorts() override;
 
   unsigned short rtp_port_0() const { return rtp_port_0_; }
   unsigned short rtp_port_1() const { return rtp_port_1_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned short rtp_port_0_;

--- a/wfd/parser/connectortype.cpp
+++ b/wfd/parser/connectortype.cpp
@@ -38,7 +38,7 @@ ConnectorType::ConnectorType(unsigned short connector_type)
 ConnectorType::~ConnectorType() {
 }
 
-std::string ConnectorType::to_string() const {
+std::string ConnectorType::ToString() const {
   std::string ret = PropertyName::wfd_connector_type + std::string(SEMICOLON)
     + std::string(SPACE);
 

--- a/wfd/parser/connectortype.h
+++ b/wfd/parser/connectortype.h
@@ -31,10 +31,10 @@ class ConnectorType: public Property {
  public:
   ConnectorType();
   explicit ConnectorType(unsigned short connector_type);
-  virtual ~ConnectorType();
+  ~ConnectorType() override;
 
   unsigned short connector_type() const { return connector_type_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned short connector_type_;

--- a/wfd/parser/contentprotection.cpp
+++ b/wfd/parser/contentprotection.cpp
@@ -49,7 +49,7 @@ ContentProtection::HDCPSpec ContentProtection::hdcp_spec() const {
   return hdcp_spec_;
 }
 
-std::string ContentProtection::to_string() const {
+std::string ContentProtection::ToString() const {
   std::string ret =
       PropertyName::wfd_content_protection
     + std::string(SEMICOLON) + std::string(SPACE);

--- a/wfd/parser/contentprotection.h
+++ b/wfd/parser/contentprotection.h
@@ -37,11 +37,11 @@ class ContentProtection: public Property {
  public:
   ContentProtection();
   ContentProtection(HDCPSpec hdcp_spec, unsigned int port);
-  virtual ~ContentProtection();
+  ~ContentProtection() override;
 
   HDCPSpec hdcp_spec() const;
   unsigned int port() const { return port_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   HDCPSpec hdcp_spec_;

--- a/wfd/parser/coupledsink.cpp
+++ b/wfd/parser/coupledsink.cpp
@@ -40,7 +40,7 @@ CoupledSink::CoupledSink(): Property(WFD_COUPLED_SINK, true){
 CoupledSink::~CoupledSink(){
 }
 
-std::string CoupledSink::to_string() const {
+std::string CoupledSink::ToString() const {
   std::string ret =
       PropertyName::wfd_coupled_sink + std::string(SEMICOLON)
     + std::string(SPACE);

--- a/wfd/parser/coupledsink.h
+++ b/wfd/parser/coupledsink.h
@@ -31,11 +31,11 @@ class CoupledSink: public Property {
  public:
   CoupledSink();
   CoupledSink(unsigned char status, unsigned long long int sink_address);
-  virtual ~CoupledSink();
+  ~CoupledSink() override;
 
   unsigned char status() const { return status_; }
   unsigned long long int sink_address() const { return sink_address_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned short status_;

--- a/wfd/parser/displayedid.cpp
+++ b/wfd/parser/displayedid.cpp
@@ -39,7 +39,7 @@ DisplayEdid::DisplayEdid(unsigned short edid_block_count,
 DisplayEdid::~DisplayEdid() {
 }
 
-std::string DisplayEdid::to_string() const {
+std::string DisplayEdid::ToString() const {
 
   std::string ret =
       PropertyName::wfd_display_edid + std::string(SEMICOLON)

--- a/wfd/parser/displayedid.h
+++ b/wfd/parser/displayedid.h
@@ -31,11 +31,11 @@ class DisplayEdid: public Property {
  public:
   DisplayEdid();
   DisplayEdid(unsigned short edid_block_count, std::string edid_payload);
-  virtual ~DisplayEdid();
+  ~DisplayEdid() override;
 
   unsigned short block_count() const { return edid_block_count_; }
   const std::string& payload() const { return edid_payload_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned short edid_block_count_;

--- a/wfd/parser/errorscanner.h
+++ b/wfd/parser/errorscanner.h
@@ -39,7 +39,7 @@ class ErrorScanner : public yyFlexLexer, public BaseLexer {
    BaseLexer() {};
 
  private:
-  virtual int yylex() override;
+  int yylex() override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/formats3d.cpp
+++ b/wfd/parser/formats3d.cpp
@@ -42,7 +42,7 @@ Formats3d::~Formats3d() {
   // TODO Auto-generated destructor stub
 }
 
-std::string H264Codec3d::to_string() const {
+std::string H264Codec3d::ToString() const {
   std::string ret;
   MAKE_HEX_STRING_2(profile, profile_);
   MAKE_HEX_STRING_2(level, level_);
@@ -78,7 +78,7 @@ std::string H264Codec3d::to_string() const {
   return ret;
 }
 
-std::string Formats3d::to_string() const {
+std::string Formats3d::ToString() const {
   std::string ret;
 
   ret = PropertyName::wfd_3d_formats
@@ -96,7 +96,7 @@ std::string Formats3d::to_string() const {
   auto it = h264_codecs_3d_.begin();
   auto end = h264_codecs_3d_.end();
   while(it != end) {
-    ret += (*it).to_string();
+    ret += (*it).ToString();
     ++it;
     if (it != end)
       ret += ", ";

--- a/wfd/parser/formats3d.h
+++ b/wfd/parser/formats3d.h
@@ -48,7 +48,7 @@ struct H264Codec3d {
       max_hres_(max_hres),
       max_vres_(max_vres) {}
 
-  std::string to_string() const;
+  std::string ToString() const;
 
   unsigned char profile_;
   unsigned char level_;
@@ -69,13 +69,13 @@ class Formats3d: public Property {
   Formats3d(unsigned char native,
             unsigned char preferred_display_mode,
             const H264Codecs3d& h264_codecs_3d);
-  virtual ~Formats3d();
+  ~Formats3d() override;
 
   unsigned char native_resolution() const { return native_; }
   unsigned char preferred_display_mode() const { return preferred_display_mode_;}
   const H264Codecs3d& codecs() const { return h264_codecs_3d_; }
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned char native_;

--- a/wfd/parser/genericproperty.cpp
+++ b/wfd/parser/genericproperty.cpp
@@ -38,7 +38,7 @@ GenericProperty::GenericProperty(const std::string& key, const std::string& valu
 GenericProperty::~GenericProperty() {
 }
 
-std::string GenericProperty::to_string() const{
+std::string GenericProperty::ToString() const{
   return key_ + ": " + value_;
 }
 

--- a/wfd/parser/genericproperty.h
+++ b/wfd/parser/genericproperty.h
@@ -32,12 +32,12 @@ class GenericProperty: public Property {
     GenericProperty();
     GenericProperty(const std::string& key, const std::string& value);
 
-    virtual ~GenericProperty();
+    ~GenericProperty() override;
 
     const std::string& key () const { return key_; }
     const std::string& value () const { return value_; }
 
-    virtual std::string to_string() const override;
+    std::string ToString() const override;
   private:
     std::string key_;
     std::string value_;

--- a/wfd/parser/getparameter.cpp
+++ b/wfd/parser/getparameter.cpp
@@ -31,11 +31,11 @@ GetParameter::GetParameter(const std::string& request_uri)
 GetParameter::~GetParameter() {
 }
 
-std::string GetParameter::to_string() const {
+std::string GetParameter::ToString() const {
   std::string ret = MethodName::GET_PARAMETER
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/getparameter.h
+++ b/wfd/parser/getparameter.h
@@ -30,8 +30,8 @@ namespace wfd {
 class GetParameter : public Request {
  public:
     explicit GetParameter(const std::string& request_uri);
-    virtual ~GetParameter();
-    virtual std::string to_string() const override;
+    ~GetParameter() override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/header.cpp
+++ b/wfd/parser/header.cpp
@@ -128,7 +128,7 @@ bool Header::has_method(const Method& method) const {
       method) != supported_methods_.end();
 }
 
-std::string Header::to_string() const {
+std::string Header::ToString() const {
   std::string ret;
 
   ret += kCSeq + std::to_string(cseq_) + wfd::CRLF;
@@ -147,7 +147,7 @@ std::string Header::to_string() const {
   if (content_length_)
     ret += kContentLenght + std::to_string(content_length_) + wfd::CRLF;
 
-  ret += transport().to_string();
+  ret += transport().ToString();
 
   if (supported_methods_.size()) {
     auto i = supported_methods_.begin();

--- a/wfd/parser/header.h
+++ b/wfd/parser/header.h
@@ -68,7 +68,7 @@ class Header {
     void add_generic_header(const std::string& key ,const std::string& value);
     const GenericHeaderMap& generic_headers () const;
 
-    virtual std::string to_string() const;
+    std::string ToString() const;
 
  private:
     int cseq_;

--- a/wfd/parser/headerscanner.h
+++ b/wfd/parser/headerscanner.h
@@ -38,7 +38,7 @@ class HeaderScanner : public yyFlexLexer, public BaseLexer {
    BaseLexer() {};
 
  private:
-  virtual int yylex() override;
+  int yylex() override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/i2c.cpp
+++ b/wfd/parser/i2c.cpp
@@ -30,7 +30,7 @@ I2C::I2C(int port) : Property(WFD_I2C), port_(port) {
 I2C::~I2C() {
 }
 
-std::string I2C::to_string() const {
+std::string I2C::ToString() const {
   std::string ret = PropertyName::wfd_I2C + std::string(SEMICOLON)
     + std::string(SPACE) + (is_supported() ? std::to_string(port()) : wfd::NONE);
   return ret;

--- a/wfd/parser/i2c.h
+++ b/wfd/parser/i2c.h
@@ -30,11 +30,11 @@ namespace wfd {
 class I2C: public Property {
  public:
   explicit I2C(int port);
-  virtual ~I2C();
+  ~I2C() override;
 
   bool is_supported() const { return port_ > 0; }
   int port() const { return port_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   int port_;

--- a/wfd/parser/idrrequest.cpp
+++ b/wfd/parser/idrrequest.cpp
@@ -30,7 +30,7 @@ IDRRequest::IDRRequest() : Property(WFD_IDR_REQUEST) {
 IDRRequest::~IDRRequest() {
 }
 
-std::string IDRRequest::to_string() const {
+std::string IDRRequest::ToString() const {
   return std::string("wfd_idr_request");
 }
 

--- a/wfd/parser/idrrequest.h
+++ b/wfd/parser/idrrequest.h
@@ -30,9 +30,9 @@ namespace wfd {
 class IDRRequest: public Property {
 public:
   IDRRequest();
-  virtual ~IDRRequest();
+  ~IDRRequest() override;
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/message.cpp
+++ b/wfd/parser/message.cpp
@@ -50,14 +50,14 @@ Payload& Message::payload() {
   return *payload_;
 }
 
-std::string Message::to_string() const {
+std::string Message::ToString() const {
   std::string ret;
   if (payload_)
-    ret = payload_->to_string();
+    ret = payload_->ToString();
 
   if (header_) {
     header_->set_content_length (ret.length());
-    ret = header_->to_string() + ret;
+    ret = header_->ToString() + ret;
   }
 
   return ret;

--- a/wfd/parser/message.h
+++ b/wfd/parser/message.h
@@ -52,7 +52,7 @@ class Message {
 
   Payload& payload();
 
-  virtual std::string to_string() const;
+  virtual std::string ToString() const;
 
  protected:
   std::unique_ptr<Header> header_;
@@ -80,7 +80,7 @@ class Request : public Message {
   };
 
   Request(RTSPMethod method, const std::string& request_uri = std::string());
-  virtual ~Request();
+  ~Request() override;
 
   const std::string& request_uri() const { return request_uri_; }
   void set_request_uri(const std::string& request_uri) {

--- a/wfd/parser/messagescanner.h
+++ b/wfd/parser/messagescanner.h
@@ -40,7 +40,7 @@ class MessageScanner : public yyFlexLexer, public BaseLexer {
 
  private:
   bool is_reply_message_;
-  virtual int yylex() override;
+  int yylex() override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/options.cpp
+++ b/wfd/parser/options.cpp
@@ -31,11 +31,11 @@ Options::Options(const std::string& request_uri)
 Options::~Options() {
 }
 
-std::string Options::to_string() const {
+std::string Options::ToString() const {
   std::string ret = MethodName::OPTIONS
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } // namespace wfd

--- a/wfd/parser/options.h
+++ b/wfd/parser/options.h
@@ -30,8 +30,8 @@ namespace wfd {
 class Options: public Request {
   public:
     explicit Options(const std::string& request_uri);
-    virtual ~Options();
-    virtual std::string to_string() const override;
+    ~Options() override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/pause.cpp
+++ b/wfd/parser/pause.cpp
@@ -31,11 +31,11 @@ Pause::Pause(const std::string& request_uri)
 Pause::~Pause() {
 }
 
-std::string Pause::to_string() const {
+std::string Pause::ToString() const {
   std::string ret = MethodName::PAUSE
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/pause.h
+++ b/wfd/parser/pause.h
@@ -30,8 +30,8 @@ namespace wfd {
 class Pause : public Request {
  public:
     explicit Pause(const std::string& request_uri);
-    virtual ~Pause();
-    virtual std::string to_string() const override;
+    ~Pause() override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/payload.cpp
+++ b/wfd/parser/payload.cpp
@@ -116,14 +116,14 @@ const std::vector<std::string>& Payload::get_parameter_properties() const {
   return request_properties_;
 }
 
-std::string Payload::to_string() const {
+std::string Payload::ToString() const {
   std::string ret;
   auto i = properties_.begin();
   auto end = properties_.end();
 
   while(i != end) {
     if ((*i).second) {
-      ret += (*i).second->to_string();
+      ret += (*i).second->ToString();
       ret += "\r\n";
     }
     ++i;
@@ -139,7 +139,7 @@ std::string Payload::to_string() const {
 
   auto error_i = property_errors_.rbegin();
   while(error_i != property_errors_.rend()) {
-    ret += error_i->second->to_string();
+    ret += error_i->second->ToString();
     ret += "\r\n";
     error_i++;
   }

--- a/wfd/parser/payload.h
+++ b/wfd/parser/payload.h
@@ -60,7 +60,7 @@ class Payload {
   void add_property_error(const std::shared_ptr<wfd::PropertyErrors>& errors);
   const PropertyErrorMap& property_errors() const;
 
-  virtual std::string to_string() const;
+  std::string ToString() const;
 
  private:
   PropertyMap properties_;

--- a/wfd/parser/play.cpp
+++ b/wfd/parser/play.cpp
@@ -28,14 +28,11 @@ Play::Play(const std::string& request_uri)
  : Request(Request::MethodPlay, request_uri) {
 }
 
-Play::~Play() {
-}
-
-std::string Play::to_string() const {
+std::string Play::ToString() const {
   std::string ret = MethodName::PLAY
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/play.h
+++ b/wfd/parser/play.h
@@ -30,8 +30,7 @@ namespace wfd {
 class Play : public Request {
  public:
     explicit Play(const std::string& request_uri);
-    virtual ~Play();
-    virtual std::string to_string() const override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/preferreddisplaymode.cpp
+++ b/wfd/parser/preferreddisplaymode.cpp
@@ -48,7 +48,7 @@ PreferredDisplayMode::PreferredDisplayMode(
     h264_codec_(h264_codec) {
 }
 
-std::string PreferredDisplayMode::to_string() const {
+std::string PreferredDisplayMode::ToString() const {
   MAKE_HEX_STRING_6(p_clock, p_clock_);
   MAKE_HEX_STRING_4(h, h_);
   MAKE_HEX_STRING_4(hb, hb_);
@@ -76,7 +76,7 @@ std::string PreferredDisplayMode::to_string() const {
   + std::string(SPACE) + vbs3d
   + std::string(SPACE) + modes_2d_s3d
   + std::string(SPACE) + p_depth
-  + std::string(SPACE) + h264_codec_.to_string();
+  + std::string(SPACE) + h264_codec_.ToString();
   return ret;
 }
 

--- a/wfd/parser/preferreddisplaymode.h
+++ b/wfd/parser/preferreddisplaymode.h
@@ -37,7 +37,7 @@ class PreferredDisplayMode: public Property {
       unsigned short vsw, unsigned char vbs3d, unsigned char modes_2d_s3d,
       unsigned char p_depth, const H264Codec& h264_codec);
 
-  virtual ~PreferredDisplayMode();
+  ~PreferredDisplayMode() override;
 
   unsigned int p_clock() const { return p_clock_; }
   unsigned short h() const { return h_; }
@@ -53,7 +53,7 @@ class PreferredDisplayMode: public Property {
   unsigned char p_depth() const { return p_depth_; }
   const H264Codec& h264_codec() const { return h264_codec_; }
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned int p_clock_;

--- a/wfd/parser/presentationurl.cpp
+++ b/wfd/parser/presentationurl.cpp
@@ -34,7 +34,7 @@ PresentationUrl::PresentationUrl(const std::string& presentation_url_1,
 PresentationUrl::~PresentationUrl() {
 }
 
-std::string PresentationUrl::to_string() const {
+std::string PresentationUrl::ToString() const {
   std::string ret =
       PropertyName::wfd_presentation_url + std::string(SEMICOLON)
     + std::string(SPACE)

--- a/wfd/parser/presentationurl.h
+++ b/wfd/parser/presentationurl.h
@@ -31,11 +31,11 @@ class PresentationUrl: public Property {
  public:
   PresentationUrl(const std::string& presentation_url_1,
       const std::string presentation_url_2);
-  virtual ~PresentationUrl();
+  ~PresentationUrl() override;
 
   const std::string& presentation_url_1() const { return presentation_url_1_; }
   const std::string& presentation_url_2() const { return presentation_url_2_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   std::string presentation_url_1_;

--- a/wfd/parser/property.cpp
+++ b/wfd/parser/property.cpp
@@ -38,7 +38,7 @@ Property::~Property() {
 	// TODO Auto-generated destructor stub
 }
 
-std::string Property::to_string() const {
+std::string Property::ToString() const {
   return std::string();
 }
 

--- a/wfd/parser/property.h
+++ b/wfd/parser/property.h
@@ -34,7 +34,7 @@ class Property {
  public:
   explicit Property(PropertyType type);
   virtual ~Property();
-  virtual std::string to_string() const;
+  virtual std::string ToString() const;
 
   PropertyType type() { return type_; }
   bool is_none() const { return is_none_; }

--- a/wfd/parser/propertyerrors.cpp
+++ b/wfd/parser/propertyerrors.cpp
@@ -42,7 +42,7 @@ PropertyErrors::PropertyErrors(const std::string& generic_property_name, std::ve
 PropertyErrors::~PropertyErrors() {
 }
 
-std::string PropertyErrors::to_string() const {
+std::string PropertyErrors::ToString() const {
   std::string ret;
 
   if (type_ == WFD_GENERIC)

--- a/wfd/parser/propertyerrors.h
+++ b/wfd/parser/propertyerrors.h
@@ -40,7 +40,7 @@ class PropertyErrors {
   const std::vector<unsigned short>& error_codes() const { return error_codes_; }
   const std::string& generic_property_name() const {return generic_property_name_; }
 
-  std::string to_string() const;
+  std::string ToString() const;
 
  private:
   PropertyType type_;

--- a/wfd/parser/reply.cpp
+++ b/wfd/parser/reply.cpp
@@ -37,11 +37,11 @@ Reply::Reply(int response_code)
 Reply::~Reply() {
 }
 
-std::string Reply::to_string() const {
+std::string Reply::ToString() const {
   std::string ret;
   ret += kRTSPHeader + std::to_string(response_code_)
        + std::string(SPACE) + kOK + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 }  // namespace wfd

--- a/wfd/parser/reply.h
+++ b/wfd/parser/reply.h
@@ -30,12 +30,12 @@ namespace wfd {
 class Reply: public Message {
  public:
   explicit Reply(int response_code = 200);
-  virtual ~Reply();
+  ~Reply() override;
 
   int response_code() const { return response_code_; }
   void set_response_code(int response_code) { response_code_ = response_code; }
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   int response_code_;

--- a/wfd/parser/route.cpp
+++ b/wfd/parser/route.cpp
@@ -37,7 +37,7 @@ Route::Route(const Route::Destination& destination)
 Route::~Route() {
 }
 
-std::string Route::to_string() const {
+std::string Route::ToString() const {
   std::string ret = PropertyName::wfd_route+ std::string(SEMICOLON)
     + std::string(SPACE) + (destination() == PRIMARY ? primary : secondary);
   return ret;

--- a/wfd/parser/route.h
+++ b/wfd/parser/route.h
@@ -36,10 +36,10 @@ class Route: public Property {
 
  public:
   explicit Route(const Route::Destination& destination);
-  virtual ~Route();
+  ~Route() override;
 
   Route::Destination destination() const { return destination_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   Route::Destination destination_;

--- a/wfd/parser/setparameter.cpp
+++ b/wfd/parser/setparameter.cpp
@@ -29,14 +29,11 @@ SetParameter::SetParameter(const std::string& request_uri)
  : Request(Request::MethodSetParameter, request_uri) {
 }
 
-SetParameter::~SetParameter() {
-}
-
-std::string SetParameter::to_string() const {
+std::string SetParameter::ToString() const {
   std::string ret = MethodName::SET_PARAMETER
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/setparameter.h
+++ b/wfd/parser/setparameter.h
@@ -30,8 +30,7 @@ namespace wfd {
 class SetParameter : public Request {
  public:
     explicit SetParameter(const std::string& request_uri);
-    virtual ~SetParameter();
-    virtual std::string to_string() const override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/setup.cpp
+++ b/wfd/parser/setup.cpp
@@ -31,11 +31,11 @@ Setup::Setup(const std::string& request_uri)
 Setup::~Setup() {
 }
 
-std::string Setup::to_string() const {
+std::string Setup::ToString() const {
   std::string ret = MethodName::SETUP
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/setup.h
+++ b/wfd/parser/setup.h
@@ -30,8 +30,8 @@ namespace wfd {
 class Setup : public Request {
  public:
     explicit Setup(const std::string& request_uri);
-    virtual ~Setup();
-    virtual std::string to_string() const override;
+    ~Setup() override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/standby.cpp
+++ b/wfd/parser/standby.cpp
@@ -30,7 +30,7 @@ Standby::Standby() : Property(WFD_STANDBY) {
 Standby::~Standby() {
 }
 
-std::string Standby::to_string() const {
+std::string Standby::ToString() const {
   return std::string("wfd_standby");
 }
 

--- a/wfd/parser/standby.h
+++ b/wfd/parser/standby.h
@@ -30,8 +30,8 @@ namespace wfd {
 class Standby: public Property {
 public:
   Standby();
-  virtual ~Standby();
-  virtual std::string to_string() const override;
+  ~Standby() override;
+  std::string ToString() const override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/standbyresumecapability.cpp
+++ b/wfd/parser/standbyresumecapability.cpp
@@ -35,7 +35,7 @@ StandbyResumeCapability::StandbyResumeCapability(bool is_supported)
 StandbyResumeCapability::~StandbyResumeCapability() {
 }
 
-std::string StandbyResumeCapability::to_string() const {
+std::string StandbyResumeCapability::ToString() const {
   std::string ret =
       PropertyName::wfd_standby_resume_capability + std::string(SEMICOLON)
      + std::string(SPACE) + (is_none() ? wfd::NONE : supported);

--- a/wfd/parser/standbyresumecapability.h
+++ b/wfd/parser/standbyresumecapability.h
@@ -30,9 +30,9 @@ namespace wfd {
 class StandbyResumeCapability: public Property {
 public:
   explicit StandbyResumeCapability(bool is_supported);
-  virtual ~StandbyResumeCapability();
+  ~StandbyResumeCapability() override;
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 };
 
 }  // namespace wfd

--- a/wfd/parser/teardown.cpp
+++ b/wfd/parser/teardown.cpp
@@ -31,11 +31,11 @@ Teardown::Teardown(const std::string& request_uri)
 Teardown::~Teardown() {
 }
 
-std::string Teardown::to_string() const {
+std::string Teardown::ToString() const {
   std::string ret = MethodName::TEARDOWN
       + std::string(SPACE) + request_uri()
       + std::string(SPACE) + std::string(RTSP_END) + std::string(CRLF);
-  return ret + Message::to_string();
+  return ret + Message::ToString();
 }
 
 } /* namespace wfd */

--- a/wfd/parser/teardown.h
+++ b/wfd/parser/teardown.h
@@ -30,8 +30,8 @@ namespace wfd {
 class Teardown : public Request {
  public:
     explicit Teardown(const std::string& request_uri);
-    virtual ~Teardown();
-    virtual std::string to_string() const override;
+    ~Teardown() override;
+    std::string ToString() const override;
 };
 
 } // namespace wfd

--- a/wfd/parser/tests.cpp
+++ b/wfd/parser/tests.cpp
@@ -156,7 +156,7 @@ static bool test_valid_options ()
   ASSERT_EQUAL(request->header().cseq(), 0);
   ASSERT_EQUAL(request->header().content_length(), 0);
   ASSERT_EQUAL(request->header().require_wfd_support(), true);
-  ASSERT_EQUAL (request->to_string(), header);
+  ASSERT_EQUAL (request->ToString(), header);
 
   return true;
 }
@@ -194,7 +194,7 @@ static bool test_valid_options_reply ()
     ASSERT(method != methods.end());
   }
 
-  ASSERT_EQUAL (reply->to_string(), header);
+  ASSERT_EQUAL (reply->ToString(), header);
 
   return true;
 }
@@ -234,7 +234,7 @@ static bool test_valid_extra_properties ()
   auto extra_property = std::static_pointer_cast<wfd::GenericProperty>(property);
   ASSERT_EQUAL(extra_property->value(), "1!!1! non standard value");
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -273,7 +273,7 @@ static bool test_valid_extra_errors ()
   ASSERT_EQUAL(error->error_codes()[0], 101);
   ASSERT_EQUAL(error->error_codes()[1], 102);
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -304,7 +304,7 @@ static bool test_valid_extra_properties_in_get ()
   ASSERT_EQUAL(properties[0], "nonstandard_property");
   ASSERT_EQUAL(properties[1], "wfd_audio_codecs");
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -355,7 +355,7 @@ static bool test_valid_get_parameter ()
   ASSERT(property_type_exists (properties, wfd::PropertyType::WFD_STANDBY_RESUME_CAPABILITY));
   ASSERT(property_type_exists (properties, wfd::PropertyType::WFD_CONTENT_PROTECTION));
 
-  ASSERT_EQUAL (message->to_string(), header + payload_buffer)
+  ASSERT_EQUAL (message->ToString(), header + payload_buffer)
 
   return true;
 }
@@ -469,7 +469,7 @@ static bool test_valid_get_parameter_reply_with_all_none ()
   auto uibc_setting = std::static_pointer_cast<wfd::UIBCSetting> (prop);
   ASSERT_EQUAL(uibc_setting->is_enabled(), false);
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -580,7 +580,7 @@ static bool test_valid_get_parameter_reply ()
       payload.get_property(wfd::PropertyType::WFD_STANDBY_RESUME_CAPABILITY));
   ASSERT(!prop->is_none());
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -679,7 +679,7 @@ static bool test_valid_get_parameter_reply_with_errors ()
   ASSERT_EQUAL(error->error_codes().size(), 1);
   ASSERT_EQUAL(error->error_codes()[0], 404);
 
-  ASSERT_EQUAL(message->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(message->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -744,7 +744,7 @@ static bool test_valid_set_parameter ()
   ASSERT_NO_EXCEPTION (prop =
       payload.get_property(wfd::PropertyType::WFD_PRESENTATION_URL));
 
-  ASSERT_EQUAL(request->to_string(), header + payload_buffer);
+  ASSERT_EQUAL(request->ToString(), header + payload_buffer);
 
   return true;
 }
@@ -775,7 +775,7 @@ static bool test_valid_setup ()
   ASSERT_EQUAL(request->header().transport().server_port(), 0);
   ASSERT_EQUAL(request->header().transport().server_supports_rtcp(), false);
 
-  ASSERT_EQUAL(request->to_string(), header);
+  ASSERT_EQUAL(request->ToString(), header);
 
   return true;
 }
@@ -807,7 +807,7 @@ static bool test_valid_setup_reply ()
   ASSERT_EQUAL(reply->header().transport().server_port(), 5000);
   ASSERT_EQUAL(reply->header().transport().server_supports_rtcp(), true);
 
-  ASSERT_EQUAL(reply->to_string(), header);
+  ASSERT_EQUAL(reply->ToString(), header);
 
   return true;
 }
@@ -832,7 +832,7 @@ static bool test_valid_play ()
   ASSERT_EQUAL(request->header().require_wfd_support(), false);
   ASSERT_EQUAL(request->header().session(), "6B8B4567");
 
-  ASSERT_EQUAL(request->to_string(), header);
+  ASSERT_EQUAL(request->ToString(), header);
 
   return true;
 }

--- a/wfd/parser/transportheader.cpp
+++ b/wfd/parser/transportheader.cpp
@@ -73,7 +73,7 @@ void TransportHeader::set_server_supports_rtcp(bool server_supports_rtcp) {
   server_supports_rtcp_ = server_supports_rtcp;
 }
 
-std::string TransportHeader::to_string() const {
+std::string TransportHeader::ToString() const {
   std::string ret;
 
   if (client_port_ > 0) {

--- a/wfd/parser/transportheader.h
+++ b/wfd/parser/transportheader.h
@@ -44,7 +44,7 @@ class TransportHeader {
     bool server_supports_rtcp() const;
     void set_server_supports_rtcp(bool server_supports_rtcp);
 
-    virtual std::string to_string() const;
+    std::string ToString() const;
 
  private:
     unsigned int client_port_;

--- a/wfd/parser/triggermethod.cpp
+++ b/wfd/parser/triggermethod.cpp
@@ -37,7 +37,7 @@ TriggerMethod::TriggerMethod(TriggerMethod::Method method)
 TriggerMethod::~TriggerMethod() {
 }
 
-std::string TriggerMethod::to_string() const {
+std::string TriggerMethod::ToString() const {
   std::string ret =
       PropertyName::wfd_trigger_method + std::string(SEMICOLON)
     + std::string(SPACE) + name[method()];

--- a/wfd/parser/triggermethod.h
+++ b/wfd/parser/triggermethod.h
@@ -38,10 +38,10 @@ class TriggerMethod : public Property {
 
  public:
   explicit TriggerMethod(TriggerMethod::Method method);
-  virtual ~TriggerMethod();
+  ~TriggerMethod() override;
 
   TriggerMethod::Method method() const { return method_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   TriggerMethod::Method method_;

--- a/wfd/parser/uibccapability.cpp
+++ b/wfd/parser/uibccapability.cpp
@@ -90,7 +90,7 @@ UIBCCapability::UIBCCapability(
 UIBCCapability::~UIBCCapability() {
 }
 
-std::string UIBCCapability::to_string() const {
+std::string UIBCCapability::ToString() const {
   std::string ret;
   ret = PropertyName::wfd_uibc_capability + std::string(SEMICOLON)
   + std::string(SPACE);

--- a/wfd/parser/uibccapability.h
+++ b/wfd/parser/uibccapability.h
@@ -65,9 +65,9 @@ class UIBCCapability: public Property {
       const std::vector<InputType>& generic_capabilities,
       const std::vector<DetailedCapability> hidc_capabilities,
       int tcp_port);
-  virtual ~UIBCCapability();
+  ~UIBCCapability() override;
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
 

--- a/wfd/parser/uibcsetting.cpp
+++ b/wfd/parser/uibcsetting.cpp
@@ -38,7 +38,7 @@ UIBCSetting::UIBCSetting(bool is_enabled)
 UIBCSetting::~UIBCSetting() {
 }
 
-std::string UIBCSetting::to_string() const {
+std::string UIBCSetting::ToString() const {
   std::string ret =
       PropertyName::wfd_uibc_setting + std::string(SEMICOLON)
      + std::string(SPACE) + (is_enabled() ? enable : disable);

--- a/wfd/parser/uibcsetting.h
+++ b/wfd/parser/uibcsetting.h
@@ -30,10 +30,10 @@ namespace wfd {
 class UIBCSetting : public Property {
  public:
   explicit UIBCSetting(bool is_enabled);
-  virtual ~UIBCSetting();
+  ~UIBCSetting() override;
 
   bool is_enabled() const { return is_enabled_; }
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   bool is_enabled_;

--- a/wfd/parser/videoformats.cpp
+++ b/wfd/parser/videoformats.cpp
@@ -60,7 +60,7 @@ H264Codec::H264Codec(H264VideoFormat format)
 
 }
 
-std::string H264Codec::to_string() const {
+std::string H264Codec::ToString() const {
   std::string ret;
   MAKE_HEX_STRING_2(profile, profile_);
   MAKE_HEX_STRING_2(level, level_);
@@ -211,7 +211,7 @@ std::vector<H264VideoFormat> VideoFormats::GetSupportedH264Formats() const {
   return result;
 }
 
-std::string VideoFormats::to_string() const {
+std::string VideoFormats::ToString() const {
   std::string ret;
 
   ret = PropertyName::wfd_video_formats
@@ -229,7 +229,7 @@ std::string VideoFormats::to_string() const {
   auto it = h264_codecs_.begin();
   auto end = h264_codecs_.end();
   while(it != end) {
-    ret += (*it).to_string();
+    ret += (*it).ToString();
     ++it;
     if (it != end)
       ret += ", ";

--- a/wfd/parser/videoformats.h
+++ b/wfd/parser/videoformats.h
@@ -43,7 +43,7 @@ struct H264Codec {
 
   H264VideoFormat ToVideoFormat() const;
 
-  std::string to_string() const;
+  std::string ToString() const;
 
  private:
   unsigned char profile_;
@@ -70,12 +70,12 @@ class VideoFormats: public Property {
   VideoFormats(unsigned char native,
                unsigned char preferred_display_mode,
                const H264Codecs& h264_codecs);
-  virtual ~VideoFormats();
+  ~VideoFormats() override;
 
   NativeVideoFormat GetNativeFormat() const;
   std::vector<H264VideoFormat> GetSupportedH264Formats() const;
 
-  virtual std::string to_string() const override;
+  std::string ToString() const override;
 
  private:
   unsigned char native_;

--- a/wfd/public/source.h
+++ b/wfd/public/source.h
@@ -33,8 +33,6 @@ class SourceMediaManager;
  */
 class Source : public Peer {
  public:
-  virtual ~Source() {}
-
   /**
    * Factory method that creates Source state machine.
    * @param delegate that is used for networking

--- a/wfd/sink/cap_negotiation_state.cpp
+++ b/wfd/sink/cap_negotiation_state.cpp
@@ -142,7 +142,7 @@ class M5Handler final : public MessageReceiver<Request::M5> {
   M5Handler(const InitParams& init_params)
     : MessageReceiver<Request::M5>(init_params) {
   }
-  virtual std::unique_ptr<Reply> HandleMessage(Message* message) override {
+  std::unique_ptr<Reply> HandleMessage(Message* message) override {
     auto property =
         static_cast<wfd::TriggerMethod*>(message->payload().get_property(wfd::WFD_TRIGGER_METHOD).get());
 
@@ -164,9 +164,6 @@ CapNegotiationState::CapNegotiationState(const InitParams &init_params)
 
   AddOptionalHandler(make_ptr(new M3Handler(init_params)));
   AddOptionalHandler(make_ptr(new M4Handler(init_params)));
-}
-
-CapNegotiationState::~CapNegotiationState() {
 }
 
 }  // sink

--- a/wfd/sink/cap_negotiation_state.h
+++ b/wfd/sink/cap_negotiation_state.h
@@ -32,19 +32,18 @@ namespace sink {
 class CapNegotiationState : public MessageSequenceWithOptionalSetHandler {
  public:
   CapNegotiationState(const InitParams& init_params);
-  virtual ~CapNegotiationState();
 };
 
 class M4Handler final : public MessageReceiver<Request::M4> {
  public:
   M4Handler(const InitParams& init_params);
-  virtual std::unique_ptr<Reply> HandleMessage(Message* message) override;
+  std::unique_ptr<Reply> HandleMessage(Message* message) override;
 };
 
 class M3Handler final : public MessageReceiver<Request::M3> {
  public:
   M3Handler(const InitParams& init_params);
-  virtual std::unique_ptr<Reply> HandleMessage(Message* message) override;
+  std::unique_ptr<Reply> HandleMessage(Message* message) override;
 };
 
 }  // namespace sink

--- a/wfd/sink/init_state.cpp
+++ b/wfd/sink/init_state.cpp
@@ -78,8 +78,5 @@ InitState::InitState(const InitParams& init_params)
   AddSequencedHandler(make_ptr(new M2Handler(init_params)));
 }
 
-InitState::~InitState() {
-}
-
 }  // sink
 }  // wfd

--- a/wfd/sink/init_state.h
+++ b/wfd/sink/init_state.h
@@ -32,7 +32,6 @@ namespace sink {
 class InitState : public MessageSequenceHandler {
  public:
   InitState(const InitParams& init_params);
-  virtual ~InitState();
 };
 
 }  // sink

--- a/wfd/sink/streaming_state.cpp
+++ b/wfd/sink/streaming_state.cpp
@@ -41,7 +41,7 @@ class M5Handler final : public MessageReceiver<Request::M5> {
     : MessageReceiver<Request::M5>(init_params) {
   }
 
-  virtual bool CanHandle(Message* message) const override {
+  bool CanHandle(Message* message) const override {
     if (!MessageReceiver<Request::M5>::CanHandle(message))
       return false;
 
@@ -50,7 +50,7 @@ class M5Handler final : public MessageReceiver<Request::M5> {
     return  method == property->method();
   }
 
-  virtual std::unique_ptr<Reply> HandleMessage(Message* message) override {
+  std::unique_ptr<Reply> HandleMessage(Message* message) override {
     return std::unique_ptr<Reply>(new Reply());
   }
 };
@@ -59,14 +59,14 @@ class M7Sender final : public SequencedMessageSender {
  public:
     using SequencedMessageSender::SequencedMessageSender;
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override {
+  std::unique_ptr<Message> CreateMessage() override {
     Play* play = new Play(ToSinkMediaManager(manager_)->PresentationUrl());
     play->header().set_session(ToSinkMediaManager(manager_)->Session());
     play->header().set_cseq (send_cseq_++);
     return std::unique_ptr<Message>(play);
   }
 
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     if (reply->response_code() == 200) {
       manager_->Play();
       return true;
@@ -88,14 +88,14 @@ class M8Sender final : public SequencedMessageSender {
  public:
   using SequencedMessageSender::SequencedMessageSender;
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override {
+  std::unique_ptr<Message> CreateMessage() override {
     Teardown* teardown = new Teardown(ToSinkMediaManager(manager_)->PresentationUrl());
     teardown->header().set_session(ToSinkMediaManager(manager_)->Session());
     teardown->header().set_cseq (send_cseq_++);
     return std::unique_ptr<Message>(teardown);
   }
 
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     if (!ToSinkMediaManager(manager_)->Session().empty() && (reply->response_code() == 200)) {
       manager_->Teardown();
       return true;
@@ -114,14 +114,14 @@ class M9Sender final : public SequencedMessageSender {
  public:
     using SequencedMessageSender::SequencedMessageSender;
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override {
+  std::unique_ptr<Message> CreateMessage() override {
     Pause* pause = new Pause(ToSinkMediaManager(manager_)->PresentationUrl());
     pause->header().set_session(ToSinkMediaManager(manager_)->Session());
     pause->header().set_cseq (send_cseq_++);
     return std::unique_ptr<Message>(pause);
   }
 
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     if (reply->response_code() == 200) {
       manager_->Pause();
       return true;
@@ -145,7 +145,7 @@ class M7SenderOptional final : public OptionalMessageSender<Request::M7> {
     : OptionalMessageSender<Request::M7>(init_params) {
   }
  private:
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     if (reply->response_code() == 200) {
       manager_->Play();
       return true;
@@ -153,7 +153,7 @@ class M7SenderOptional final : public OptionalMessageSender<Request::M7> {
     return false;
   }
 
-  virtual bool CanSend(Message* message) const override {
+  bool CanSend(Message* message) const override {
     if (OptionalMessageSender<Request::M7>::CanSend(message)
         && manager_->IsPaused())
       return true;
@@ -167,7 +167,7 @@ class M8SenderOptional final : public OptionalMessageSender<Request::M8> {
     : OptionalMessageSender<Request::M8>(init_params) {
   }
  private:
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     // todo: if successfull, switch to init state
     if (reply->response_code() == 200) {
       manager_->Teardown();
@@ -184,7 +184,7 @@ class M9SenderOptional final : public OptionalMessageSender<Request::M9> {
     : OptionalMessageSender<Request::M9>(init_params) {
   }
  private:
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     if (reply->response_code() == 200) {
       manager_->Pause();
       return true;
@@ -192,7 +192,7 @@ class M9SenderOptional final : public OptionalMessageSender<Request::M9> {
     return false;
   }
 
-  virtual bool CanSend(Message* message) const override {
+  bool CanSend(Message* message) const override {
     if (OptionalMessageSender<Request::M9>::CanSend(message)
         && !manager_->IsPaused())
       return true;
@@ -213,9 +213,6 @@ StreamingState::StreamingState(const InitParams& init_params, MessageHandlerPtr 
   AddOptionalHandler(make_ptr(new M8SenderOptional(init_params)));
   AddOptionalHandler(make_ptr(new M9SenderOptional(init_params)));
   AddOptionalHandler(m16_handler);
-}
-
-StreamingState::~StreamingState() {
 }
 
 }  // sink

--- a/wfd/sink/streaming_state.h
+++ b/wfd/sink/streaming_state.h
@@ -32,7 +32,6 @@ namespace sink {
 class StreamingState : public MessageSequenceWithOptionalSetHandler {
  public:
   StreamingState(const InitParams& init_params, MessageHandlerPtr m16_handler);
-  virtual ~StreamingState();
 };
 
 class TeardownHandler : public MessageSequenceHandler {

--- a/wfd/sink/wfd_session_state.cpp
+++ b/wfd/sink/wfd_session_state.cpp
@@ -106,8 +106,5 @@ WfdSessionState::WfdSessionState(const InitParams& init_params, MessageHandlerPt
   AddOptionalHandler(m16_handler);
 }
 
-WfdSessionState::~WfdSessionState() {
-}
-
 }  // namespace sink
 }  // namespace wfd

--- a/wfd/sink/wfd_session_state.h
+++ b/wfd/sink/wfd_session_state.h
@@ -32,8 +32,8 @@ class M6Handler final : public SequencedMessageSender {
   M6Handler(const InitParams& init_params, uint& keep_alive_timer);
 
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override;
-  virtual bool HandleReply(Reply* reply) override;
+  std::unique_ptr<Message> CreateMessage() override;
+  bool HandleReply(Reply* reply) override;
 
   uint& keep_alive_timer_;
 };
@@ -43,8 +43,8 @@ class M16Handler final : public MessageReceiver<Request::M16> {
   M16Handler(const InitParams& init_params, uint& keep_alive_timer);
 
  private:
-  virtual bool HandleTimeoutEvent(uint timer_id) const override;
-  virtual std::unique_ptr<Reply> HandleMessage(Message* message) override;
+  bool HandleTimeoutEvent(uint timer_id) const override;
+  std::unique_ptr<Reply> HandleMessage(Message* message) override;
 
   uint& keep_alive_timer_;
 };
@@ -54,7 +54,6 @@ class M16Handler final : public MessageReceiver<Request::M16> {
 class WfdSessionState : public MessageSequenceWithOptionalSetHandler {
  public:
   WfdSessionState(const InitParams& init_params, MessageHandlerPtr m6_handler, MessageHandlerPtr m16_handler);
-  virtual ~WfdSessionState();
 };
 
 }  // sink

--- a/wfd/source/cap_negotiation_state.cpp
+++ b/wfd/source/cap_negotiation_state.cpp
@@ -38,8 +38,8 @@ class M3Handler final : public SequencedMessageSender {
   using SequencedMessageSender::SequencedMessageSender;
 
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override;
-  virtual bool HandleReply(Reply* reply) override;
+  std::unique_ptr<Message> CreateMessage() override;
+  bool HandleReply(Reply* reply) override;
 };
 
 class M4Handler final : public SequencedMessageSender {
@@ -47,8 +47,8 @@ class M4Handler final : public SequencedMessageSender {
   using SequencedMessageSender::SequencedMessageSender;
 
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override;
-  virtual bool HandleReply(Reply* reply) override;
+  std::unique_ptr<Message> CreateMessage() override;
+  bool HandleReply(Reply* reply) override;
 };
 
 std::unique_ptr<Message> M3Handler::CreateMessage() {

--- a/wfd/source/cap_negotiation_state.h
+++ b/wfd/source/cap_negotiation_state.h
@@ -32,7 +32,7 @@ namespace source {
 class CapNegotiationState : public MessageSequenceHandler {
  public:
   CapNegotiationState(const InitParams& init_params);
-  virtual ~CapNegotiationState();
+  ~CapNegotiationState() override;
 };
 
 }  // source

--- a/wfd/source/init_state.cpp
+++ b/wfd/source/init_state.cpp
@@ -31,14 +31,14 @@ class M1Handler final : public SequencedMessageSender {
  public:
   using SequencedMessageSender::SequencedMessageSender;
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override {
+  std::unique_ptr<Message> CreateMessage() override {
     Options* options = new Options("*");
     options->header().set_cseq(send_cseq_++);
     options->header().set_require_wfd_support(true);
     return std::unique_ptr<Message>(options);
   }
 
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     return (reply->response_code() == 200);
   }
 
@@ -49,7 +49,7 @@ class M2Handler final : public MessageReceiver<Request::M2> {
   M2Handler(const InitParams& init_params)
     : MessageReceiver<Request::M2>(init_params) {
   }
-  virtual std::unique_ptr<Reply> HandleMessage(
+  std::unique_ptr<Reply> HandleMessage(
       Message* message) override {
     auto reply = std::unique_ptr<Reply>(new Reply(200));
     std::vector<wfd::Method> supported_methods;

--- a/wfd/source/init_state.h
+++ b/wfd/source/init_state.h
@@ -32,7 +32,7 @@ namespace source {
 class InitState : public MessageSequenceHandler {
  public:
   InitState(const InitParams& init_params);
-  virtual ~InitState();
+  ~InitState() override;
 };
 
 }  // source

--- a/wfd/source/source.cpp
+++ b/wfd/source/source.cpp
@@ -99,20 +99,20 @@ class SourceImpl final : public Source, public RTSPInputHandler, public MessageH
 
  private:
   // Source implementation.
-  virtual void Start() override;
-  virtual void RTSPDataReceived(const std::string& message) override;
-  virtual bool Teardown() override;
-  virtual bool Play() override;
-  virtual bool Pause() override;
+  void Start() override;
+  void RTSPDataReceived(const std::string& message) override;
+  bool Teardown() override;
+  bool Play() override;
+  bool Pause() override;
 
   // public MessageHandler::Observer
-  virtual void OnCompleted(MessageHandlerPtr handler) override;
-  virtual void OnError(MessageHandlerPtr handler) override;
+  void OnCompleted(MessageHandlerPtr handler) override;
+  void OnError(MessageHandlerPtr handler) override;
 
-  virtual void OnTimerEvent(uint timer_id) override;
+  void OnTimerEvent(uint timer_id) override;
 
   // RTSPInputHandler
-  virtual void MessageParsed(std::unique_ptr<Message> message) override;
+  void MessageParsed(std::unique_ptr<Message> message) override;
 
   // Keep-alive function
   void SendKeepAlive();

--- a/wfd/source/streaming_state.cpp
+++ b/wfd/source/streaming_state.cpp
@@ -35,7 +35,7 @@ class M9Handler final : public MessageReceiver<Request::M9> {
     : MessageReceiver<Request::M9>(init_params) {
   }
 
-  virtual std::unique_ptr<Reply> HandleMessage(
+  std::unique_ptr<Reply> HandleMessage(
       Message* message) override {
     int response_code = 406;
     if (!manager_->IsPaused()) {
@@ -51,7 +51,7 @@ class M5Sender final : public OptionalMessageSender<Request::M5> {
   M5Sender(const InitParams& init_params)
     : OptionalMessageSender<Request::M5>(init_params) {
   }
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     return (reply->response_code() == 200);
   }
 };

--- a/wfd/source/streaming_state.h
+++ b/wfd/source/streaming_state.h
@@ -32,7 +32,7 @@ namespace source {
 class StreamingState : public MessageSequenceWithOptionalSetHandler {
  public:
   StreamingState(const InitParams& init_params, MessageHandlerPtr m16_sender);
-  virtual ~StreamingState();
+  ~StreamingState() override;
 };
 
 }  // source

--- a/wfd/source/wfd_session_state.cpp
+++ b/wfd/source/wfd_session_state.cpp
@@ -36,7 +36,7 @@ class M5Handler final : public SequencedMessageSender {
   using SequencedMessageSender::SequencedMessageSender;
 
  private:
-  virtual std::unique_ptr<Message> CreateMessage() override {
+  std::unique_ptr<Message> CreateMessage() override {
     SetParameter* set_param = new SetParameter("rtsp://localhost/wfd1.0");
     set_param->header().set_cseq(send_cseq_++);
     set_param->payload().add_property(
@@ -44,7 +44,7 @@ class M5Handler final : public SequencedMessageSender {
     return std::unique_ptr<Message>(set_param);
   }
 
-  virtual bool HandleReply(Reply* reply) override {
+  bool HandleReply(Reply* reply) override {
     return (reply->response_code() == 200);
   }
 
@@ -57,7 +57,7 @@ class M6Handler final : public MessageReceiver<Request::M6> {
       keep_alive_timer_(timer_id) {
   }
 
-  virtual std::unique_ptr<Reply> HandleMessage(
+  std::unique_ptr<Reply> HandleMessage(
       Message* message) override {
     auto reply = std::unique_ptr<Reply>(new Reply(200));
     // todo: generate unique session id
@@ -73,7 +73,7 @@ class M6Handler final : public MessageReceiver<Request::M6> {
     return std::move(reply);
   }
 
-  virtual void Handle(std::unique_ptr<Message> message) override {
+  void Handle(std::unique_ptr<Message> message) override {
     MessageReceiver<Request::M6>::Handle(std::move(message));
     keep_alive_timer_ =
         sender_->CreateTimer(kDefaultTimeoutValue);

--- a/wfd/source/wfd_session_state.h
+++ b/wfd/source/wfd_session_state.h
@@ -33,7 +33,7 @@ class WfdSessionState : public MessageSequenceWithOptionalSetHandler {
  public:
   WfdSessionState(const InitParams& init_params, uint& timer_id,
       MessageHandlerPtr& m16_sender);
-  virtual ~WfdSessionState();
+  ~WfdSessionState() override;
 };
 
 class M8Handler final : public MessageReceiver<Request::M8> {
@@ -41,7 +41,7 @@ class M8Handler final : public MessageReceiver<Request::M8> {
   M8Handler(const InitParams& init_params);
 
  private:
-  virtual std::unique_ptr<Reply> HandleMessage(
+  std::unique_ptr<Reply> HandleMessage(
       Message* message) override;
 };
 
@@ -50,7 +50,7 @@ class M7Handler final : public MessageReceiver<Request::M7> {
   M7Handler(const InitParams& init_params);
 
  private:
-  virtual std::unique_ptr<Reply> HandleMessage(
+  std::unique_ptr<Reply> HandleMessage(
       Message* message) override;
 };
 
@@ -59,7 +59,7 @@ class M16Sender final : public OptionalMessageSender<Request::M16> {
   M16Sender(const InitParams& init_params);
 
  private:
-  virtual bool HandleReply(Reply* reply) override;
+  bool HandleReply(Reply* reply) override;
 };
 
 }  // source


### PR DESCRIPTION
Do not use 'virtual' when 'override' is used as 'override' already implies virtuality.
Rename 'to_string()' to 'ToString()'.