### PR TITLE
Sink restart fixes

### DIFF
--- a/desktop_source/mirac_broker_source.cpp
+++ b/desktop_source/mirac_broker_source.cpp
@@ -42,8 +42,13 @@ void MiracBrokerSource::on_connected() {
   wfd_source_->Start();
 }
 
-void MiracBrokerSource::on_connect_timeout() {
-  std::cout << "* RTSP connection failed: timeout" << std::endl;
+void MiracBrokerSource::on_connection_failure(ConnectionFailure failure) {
+  switch (failure) {
+      case CONNECTION_LOST:
+          std::cout << "* RTSP connection lost" << std::endl;
+      case CONNECTION_TIMEOUT:
+          std::cout << "* RTSP connection failed: timeout" << std::endl;
+  }
 }
 
 wfd::Peer* MiracBrokerSource::Peer() const {

--- a/desktop_source/mirac_broker_source.h
+++ b/desktop_source/mirac_broker_source.h
@@ -41,7 +41,7 @@ class MiracBrokerSource : public MiracBroker {
  private:
   virtual void got_message(const std::string& message) override;
   virtual void on_connected() override;
-  void on_connect_timeout() override;
+  void on_connection_failure(ConnectionFailure failure) override;
   virtual wfd::Peer* Peer() const override;
 
   std::unique_ptr<wfd::SourceMediaManager> media_manager_;

--- a/mirac_network/mirac-broker.cpp
+++ b/mirac_network/mirac-broker.cpp
@@ -72,9 +72,9 @@ gboolean MiracBroker::send_cb (gint fd, GIOCondition condition)
     try {
         if (!connection_->Send())
             return G_SOURCE_CONTINUE;
-    } catch (MiracConnectionLostException &exception) {
+    } catch (const MiracConnectionLostException &exception) {
         on_connection_failure(CONNECTION_LOST);
-    } catch (std::exception &x) {
+    } catch (const std::exception &x) {
         g_warning("exception: %s", x.what());
     }
     return G_SOURCE_REMOVE;
@@ -89,7 +89,7 @@ gboolean MiracBroker::receive_cb (gint fd, GIOCondition condition)
             g_log("rtsp", G_LOG_LEVEL_DEBUG, "Received RTSP message:\n%s", msg.c_str());
             got_message (msg);
         }
-    } catch (MiracConnectionLostException &exception) {
+    } catch (const MiracConnectionLostException &exception) {
         on_connection_failure(CONNECTION_LOST);
         return G_SOURCE_REMOVE;
     }
@@ -102,7 +102,7 @@ gboolean MiracBroker::listen_cb (gint fd, GIOCondition condition)
         connection(network_->Accept());
         g_message("connection from: %s", connection_->GetPeerAddress().c_str());
         on_connected();
-    } catch (std::exception &x) {
+    } catch (const std::exception &x) {
         g_warning("exception: %s", x.what());
     }
 
@@ -121,7 +121,7 @@ gboolean MiracBroker::connect_cb (gint fd, GIOCondition condition)
         network(NULL);
 
         on_connected();
-    } catch (std::exception &x) {
+    } catch (const std::exception &x) {
         gdouble elapsed = 1000 * g_timer_elapsed(connect_timer_, NULL);
         if (elapsed + connect_wait_ > connect_timeout_) {
             on_connection_failure(CONNECTION_TIMEOUT);

--- a/mirac_network/mirac-broker.hpp
+++ b/mirac_network/mirac-broker.hpp
@@ -73,8 +73,14 @@ class MiracBroker : public wfd::Peer::Delegate
         void handle_body(const std::string msg);
         void handle_header(const std::string msg);
 
+        void network(MiracNetwork* connection);
         std::unique_ptr<MiracNetwork> network_;
+        MiracBroker *network_source_ptr_;
+
+        void connection(MiracNetwork* connection);
         std::unique_ptr<MiracNetwork> connection_;
+        MiracBroker *connection_source_ptr_;
+
         std::vector<uint> timers_;
 
         std::string peer_address_;

--- a/mirac_network/mirac-broker.hpp
+++ b/mirac_network/mirac-broker.hpp
@@ -31,12 +31,6 @@
 #include "wfd/public/peer.h"
 #include "mirac-network.hpp"
 
-class MiracBrokerObserver
-{
-    public:
-        virtual ~MiracBrokerObserver();
-};
-
 class MiracBroker : public wfd::Peer::Delegate
 {
     public:
@@ -49,6 +43,11 @@ class MiracBroker : public wfd::Peer::Delegate
         void OnTimeout(uint timer_id);
 
     protected:
+        enum ConnectionFailure {
+            CONNECTION_TIMEOUT,
+            CONNECTION_LOST,
+        };
+
         // wfd::Peer::Delegate
         virtual void SendRTSPData(const std::string& data) override;
         virtual uint CreateTimer(int seconds);
@@ -56,7 +55,7 @@ class MiracBroker : public wfd::Peer::Delegate
 
         virtual void got_message(const std::string& data) {}
         virtual void on_connected() {};
-        virtual void on_connect_timeout() {};
+        virtual void on_connection_failure(ConnectionFailure failure) {};
 
     private:
         static gboolean send_cb (gint fd, GIOCondition condition, gpointer data_ptr);

--- a/p2p/connman-peer.h
+++ b/p2p/connman-peer.h
@@ -62,8 +62,7 @@ class Peer {
         static void connect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
         static void disconnect_cb (GObject *object, GAsyncResult *res, gpointer data_ptr);
 
-		void remote_ip_changed (const char *ip);
-		void local_ip_changed (const char *ip);
+		void ips_changed (const char *remote, const char *local);
 		void state_changed (const char *state);
 		void name_changed (const char *name);
         void proxy_cb (GAsyncResult *res);

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -32,15 +32,27 @@ void SinkApp::on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer
 	peer->set_observer (this);
 }
 
+void SinkApp::on_peer_removed(P2P::Client *client, std::shared_ptr<P2P::Peer> peer)
+{
+    std::cout << "* Peer removed: " << peer->name() << std::endl;
+    if (peer.get() == peer_) {
+        sink_.reset(NULL);
+        peer_ = NULL;
+    }
+}
+
 void SinkApp::on_availability_changed(P2P::Peer *peer)
 {
     if (!sink_ && peer->is_available() && peer->device_type() == P2P::SOURCE) {
         std::cout << "* Connecting to source at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
 
         sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port()), peer->local_host()));
-    } else if (sink_ && !peer->is_available()) {
+        peer_ = peer;
+    } else if (sink_ && !peer->is_available() && peer == peer_) {
+        std::cout << "* Source unavailable" << std::endl;
+
         sink_.reset(NULL);
-        std::cout << "* Source disappeared" << std::endl;
+        peer_ = NULL;
     }
 }
 

--- a/sink/sink-app.cpp
+++ b/sink/sink-app.cpp
@@ -38,6 +38,9 @@ void SinkApp::on_availability_changed(P2P::Peer *peer)
         std::cout << "* Connecting to source at " << peer->remote_host() << ":" << ntohs(peer->remote_port()) << std::endl;
 
         sink_.reset(new Sink (peer->remote_host(), ntohs(peer->remote_port()), peer->local_host()));
+    } else if (sink_ && !peer->is_available()) {
+        sink_.reset(NULL);
+        std::cout << "* Source disappeared" << std::endl;
     }
 }
 

--- a/sink/sink-app.h
+++ b/sink/sink-app.h
@@ -36,6 +36,7 @@ class SinkApp: public P2P::Client::Observer, public P2P::Peer::Observer {
 		Sink& sink() { return *sink_; }
 
 		void on_peer_added(P2P::Client *client, std::shared_ptr<P2P::Peer> peer) override;
+		void on_peer_removed(P2P::Client *client, std::shared_ptr<P2P::Peer> peer) override;
 		void on_initialized(P2P::Client *client) override {};
 		
 		void on_availability_changed(P2P::Peer *peer) override;
@@ -44,6 +45,7 @@ class SinkApp: public P2P::Client::Observer, public P2P::Peer::Observer {
 	private:
 		std::unique_ptr<P2P::Client> p2p_client_;
 		std::unique_ptr<Sink> sink_;
+		P2P::Peer *peer_;
 };
 
 #endif // SINK_APP_H

--- a/sink/sink.cpp
+++ b/sink/sink.cpp
@@ -19,6 +19,8 @@
  * 02110-1301 USA
  */
 
+#include <iostream>
+
 #include "sink.h"
 #include "gst_sink_media_manager.h"
 
@@ -37,6 +39,15 @@ void Sink::on_connected() {
   media_manager_.reset(new GstSinkMediaManager(local_host_));
   wfd_sink_.reset(wfd::Sink::Create(this, media_manager_.get()));
   wfd_sink_->Start();
+}
+
+void Sink::on_connection_failure(ConnectionFailure failure) {
+  switch (failure) {
+      case CONNECTION_LOST:
+          std::cout << "* RTSP connection lost" << std::endl;
+      case CONNECTION_TIMEOUT:
+          ;
+  }
 }
 
 void Sink::Play() {

--- a/sink/sink.h
+++ b/sink/sink.h
@@ -44,6 +44,7 @@ class Sink : public MiracBroker {
  private:
   virtual void got_message(const std::string& message) override;
   virtual void on_connected() override;
+  void on_connection_failure(ConnectionFailure failure) override;
 
   std::unique_ptr<wfd::SinkMediaManager> media_manager_;
   std::unique_ptr<wfd::Sink> wfd_sink_;


### PR DESCRIPTION
This includes little fixes to make the sink more robust and a couple of API changes in Network:
* MiracBroker::SendRTSPData() now returns false if previous send had not yet happened. 
* MiracBroker::on_connection_failure(ConnectionFailure failure) is now a combined error handler for several classes of errors