### PR TITLE
source: use correct video format in the gstreamer pipeline

### DIFF
--- a/mirac_network/mirac-gst-test-source.cpp
+++ b/mirac_network/mirac-gst-test-source.cpp
@@ -33,14 +33,14 @@ MiracGstTestSource::MiracGstTestSource (wfd_test_stream_t wfd_stream_type, std::
     std::string hostname_port = (!hostname.empty() ? "host=" + hostname + " ": " ") + (port > 0 ? "port=" + std::to_string(port) : "");
 
     if (wfd_stream_type == WFD_TEST_BOTH) {
-        gst_pipeline = "videotestsrc ! x264enc ! muxer.  audiotestsrc ! avenc_ac3 ! muxer.  mpegtsmux name=muxer ! rtpmp2tpay ! udpsink name=sink " +
+        gst_pipeline = "videotestsrc ! videoconvert ! video/x-raw,format=I420 ! x264enc ! muxer.  audiotestsrc ! avenc_ac3 ! muxer.  mpegtsmux name=muxer ! rtpmp2tpay ! udpsink name=sink " +
             hostname_port;
     } else if (wfd_stream_type == WFD_TEST_AUDIO) {
         gst_pipeline = "audiotestsrc ! avenc_ac3 ! mpegtsmux ! rtpmp2tpay ! udpsink name=sink " + hostname_port;
     } else if (wfd_stream_type == WFD_TEST_VIDEO) {
-        gst_pipeline = "videotestsrc ! x264enc ! mpegtsmux ! rtpmp2tpay ! udpsink name=sink " + hostname_port;
+        gst_pipeline = "videotestsrc ! videoconvert ! video/x-raw,format=I420 ! x264enc ! mpegtsmux ! rtpmp2tpay ! udpsink name=sink " + hostname_port;
     } else if (wfd_stream_type == WFD_DESKTOP) {
-        gst_pipeline = "ximagesrc ! videoconvert ! x264enc tune=zerolatency ! mpegtsmux ! rtpmp2tpay ! udpsink name=sink " + hostname_port;
+        gst_pipeline = "ximagesrc ! videoconvert ! video/x-raw,format=I420 ! x264enc tune=zerolatency ! mpegtsmux ! rtpmp2tpay ! udpsink name=sink " + hostname_port;
     }
 
     gst_elem = gst_parse_launch(gst_pipeline.c_str(), NULL);


### PR DESCRIPTION
This fixes the 'black screen issue' on the 3rd party sinks side.