### PR TITLE
wfd: Make max-hres and max-vres handling more correct

### DIFF
--- a/wfd/parser/formats3d.cpp
+++ b/wfd/parser/formats3d.cpp
@@ -60,7 +60,7 @@ std::string H264Codec3d::ToString() const {
       + slice_enc_params + std::string(SPACE)
       + frame_rate_control_support + std::string(SPACE);
 
-  if (max_hres_ >= 0) {
+  if (max_hres_ > 0) {
     MAKE_HEX_STRING_4(max_hres, max_hres_);
     ret += max_hres;
   } else {
@@ -68,7 +68,7 @@ std::string H264Codec3d::ToString() const {
   }
   ret += std::string(SPACE);
 
-  if (max_vres_ >= 0) {
+  if (max_vres_ > 0) {
     MAKE_HEX_STRING_4(max_vres, max_vres_);
     ret += max_vres;
   } else {

--- a/wfd/parser/formats3d.h
+++ b/wfd/parser/formats3d.h
@@ -36,8 +36,8 @@ struct H264Codec3d {
   H264Codec3d(unsigned char profile, unsigned char level,
       unsigned long long int video_capability_3d, unsigned char latency,
       unsigned short min_slice_size, unsigned short slice_enc_params,
-      unsigned char frame_rate_control_support, int max_hres,
-      int max_vres)
+      unsigned char frame_rate_control_support,
+      unsigned short max_hres, unsigned short max_vres)
     : profile_(profile),
       level_(level),
       video_capability_3d_(video_capability_3d),
@@ -57,8 +57,8 @@ struct H264Codec3d {
   unsigned short min_slice_size_;
   unsigned short slice_enc_params_;
   unsigned char frame_rate_control_support_;
-  int max_hres_;
-  int max_vres_;
+  unsigned short max_hres_;
+  unsigned short max_vres_;
 };
 
 typedef std::vector<wfd::H264Codec3d> H264Codecs3d;

--- a/wfd/parser/parser.ypp
+++ b/wfd/parser/parser.ypp
@@ -763,14 +763,14 @@ wfd_h264_codec_3d:
 
 wfd_max_hres:
     WFD_NONE {
-      $$ = -1;
+      $$ = 0;
     }
   | WFD_NUM
   ;
   
 wfd_max_vres:
     WFD_NONE {
-      $$ = -1;
+      $$ = 0;
     }
   | WFD_NUM
   ;

--- a/wfd/parser/tests.cpp
+++ b/wfd/parser/tests.cpp
@@ -466,7 +466,7 @@ static bool test_valid_get_parameter_reply ()
                       "wfd_display_edid: none\r\n"
                       "wfd_standby_resume_capability: supported\r\n"
                       "wfd_uibc_capability: none\r\n"
-                      "wfd_video_formats: 40 00 02 04 0001DEFF 053C7FFF 00000FFF 00 0000 0000 11 none none, 01 04 0001DEFF 053C7FFF 00000FFF 00 0000 0000 11 none none\r\n");
+                      "wfd_video_formats: 40 01 02 04 0001DEFF 053C7FFF 00000FFF 00 0000 0000 11 0400 0300, 01 04 0001DEFF 053C7FFF 00000FFF 00 0000 0000 11 0400 0300\r\n");
   std::unique_ptr<wfd::Message> message;
   driver.Parse(header, message);
   ASSERT(message != NULL);

--- a/wfd/parser/videoformats.cpp
+++ b/wfd/parser/videoformats.cpp
@@ -31,8 +31,8 @@ H264Codec::H264Codec(unsigned char profile, unsigned char level,
     unsigned int cea_support, unsigned int vesa_support,
     unsigned int hh_support, unsigned char latency,
     unsigned short min_slice_size, unsigned short slice_enc_params,
-    unsigned char frame_rate_control_support, int max_hres,
-    int max_vres)
+    unsigned char frame_rate_control_support,
+    unsigned short max_hres, unsigned short max_vres)
   : profile_(profile),
     level_(level),
     cea_support_(cea_support),
@@ -82,7 +82,7 @@ std::string H264Codec::ToString() const {
       + slice_enc_params + std::string(SPACE)
       + frame_rate_control_support + std::string(SPACE);
 
-  if (max_hres_ >= 0) {
+  if (max_hres_ > 0) {
     MAKE_HEX_STRING_4(max_hres, max_hres_);
     ret += max_hres;
   } else {
@@ -90,7 +90,7 @@ std::string H264Codec::ToString() const {
   }
   ret += std::string(SPACE);
 
-  if (max_vres_ >= 0) {
+  if (max_vres_ > 0) {
     MAKE_HEX_STRING_4(max_vres, max_vres_);
     ret += max_vres;
   } else {

--- a/wfd/parser/videoformats.h
+++ b/wfd/parser/videoformats.h
@@ -36,8 +36,8 @@ struct H264Codec {
       unsigned int cea_support, unsigned int vesa_support,
       unsigned int hh_support, unsigned char latency,
       unsigned short min_slice_size, unsigned short slice_enc_params,
-      unsigned char frame_rate_control_support, int max_hres,
-      int max_vres);
+      unsigned char frame_rate_control_support,
+      unsigned short max_hres, unsigned short max_vres);
 
   H264Codec(H264VideoFormat format);
 
@@ -55,8 +55,8 @@ struct H264Codec {
   unsigned short min_slice_size_;
   unsigned short slice_enc_params_;
   unsigned char frame_rate_control_support_;
-  int max_hres_;
-  int max_vres_;
+  unsigned short max_hres_;
+  unsigned short max_vres_;
 };
 
 typedef std::vector<wfd::H264Codec> H264Codecs;


### PR DESCRIPTION
The spec says
> in M3 response and if preferred-display-mode-supported is 0, then
> “none”.in M3 response and if preferred-display-mode-supported is 1,
> specifies the maximum horizontal resolution that the H.264 decoder
> supports in pixels. in M4 request, it is “none”.

Reality is that there is no case where we would have to distinguish
between "none" and "0000", except when deciding what to output.

This commit does not implement the spec above fully: If the value is
0 then output is "none", otherwise it's the value itself. So the
output is not dependent on preferred-display-mode-supported.

Fixes #64.