### PR TITLE
wfd: Don't assert on strange videoformat input

### DIFF
--- a/wfd/parser/videoformats.cpp
+++ b/wfd/parser/videoformats.cpp
@@ -127,10 +127,9 @@ std::vector<EnumType> MaskToEnumList(ArgType from, EnumType biggest_value) {
 
   while (copy != 0) {
     if ((copy & 1) != 0) {
-      if (enum_value > static_cast<unsigned>(biggest_value)) {
-        assert(false);
+      if (enum_value > static_cast<unsigned>(biggest_value))
         break;
-      }
+
       result.push_back(static_cast<EnumType>(enum_value));
     }
     copy = copy >> 1;


### PR DESCRIPTION
Skip reserved supportmask values, don't assert.

Fixes #76.

Should note that the MaskToEnum() function is still broken and would assert on same input.

@kanavin If you're fixing the codec handling, you'll probably end up rewriting these functions: so feel free to disregard if this clashes with your changes. I wanted to fix this since it makes the desktop_source work with last of our test sinks -- at least with some streaming quality.
 