### PR TITLE
Fix video formats

### DIFF
--- a/desktop_source/desktop_media_manager.cpp
+++ b/desktop_source/desktop_media_manager.cpp
@@ -41,21 +41,17 @@ int DesktopMediaManager::SourceRtpPort() const {
   return gst_pipeline_->UdpSourcePort();
 }
 
-std::vector<wfd::H264VideoFormat>
-DesktopMediaManager::SupportedH264VideoFormats() const {
-  return {format_};
-}
-
-wfd::NativeVideoFormat DesktopMediaManager::SupportedNativeVideoFormat() const {
-  return wfd::NativeVideoFormat();
+std::vector<wfd::SelectableH264VideoFormat>
+DesktopMediaManager::GetSelectableH264VideoFormats() const {
+  return {wfd::SelectableH264VideoFormat()};
 }
 
 bool DesktopMediaManager::SetOptimalFormat(
-    const wfd::H264VideoFormat& optimal_format) {
+    const wfd::SelectableH264VideoFormat& optimal_format) {
   format_ = optimal_format;
   return true;
 }
 
-wfd::H264VideoFormat DesktopMediaManager::GetOptimalFormat() const {
+wfd::SelectableH264VideoFormat DesktopMediaManager::GetOptimalFormat() const {
   return format_;
 }

--- a/desktop_source/desktop_media_manager.cpp
+++ b/desktop_source/desktop_media_manager.cpp
@@ -43,7 +43,18 @@ int DesktopMediaManager::SourceRtpPort() const {
 
 std::vector<wfd::SelectableH264VideoFormat>
 DesktopMediaManager::GetSelectableH264VideoFormats() const {
-  return {wfd::SelectableH264VideoFormat()};
+  std::vector<wfd::SelectableH264VideoFormat> formats;
+
+  wfd::RateAndResolution i;
+
+  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i = i + 1)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::CEARatesAndResolutions(i)));
+  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i = i + 1)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::VESARatesAndResolutions(i)));
+  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i = i + 1)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::HHRatesAndResolutions(i)));
+
+  return formats;
 }
 
 bool DesktopMediaManager::SetOptimalFormat(

--- a/desktop_source/desktop_media_manager.cpp
+++ b/desktop_source/desktop_media_manager.cpp
@@ -47,12 +47,12 @@ DesktopMediaManager::GetSelectableH264VideoFormats() const {
 
   wfd::RateAndResolution i;
 
-  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i = i + 1)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::CEARatesAndResolutions(i)));
-  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i = i + 1)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::VESARatesAndResolutions(i)));
-  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i = i + 1)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, wfd::HHRatesAndResolutions(i)));
+  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i++)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::CEARatesAndResolutions>(i)));
+  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i++)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::VESARatesAndResolutions>(i)));
+  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i++)
+      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::HHRatesAndResolutions>(i)));
 
   return formats;
 }

--- a/desktop_source/desktop_media_manager.h
+++ b/desktop_source/desktop_media_manager.h
@@ -17,17 +17,16 @@ class DesktopMediaManager : public wfd::SourceMediaManager {
   virtual std::pair<int,int> SinkRtpPorts() const override;
   virtual int SourceRtpPort() const override;
 
-  virtual std::vector<wfd::H264VideoFormat> SupportedH264VideoFormats() const override;
-  virtual wfd::NativeVideoFormat SupportedNativeVideoFormat() const override;
-  virtual bool SetOptimalFormat(const wfd::H264VideoFormat& optimal_format) override;
-  virtual wfd::H264VideoFormat GetOptimalFormat() const override;
+  virtual std::vector<wfd::SelectableH264VideoFormat> GetSelectableH264VideoFormats() const override;
+  virtual bool SetOptimalFormat(const wfd::SelectableH264VideoFormat& optimal_format) override;
+  virtual wfd::SelectableH264VideoFormat GetOptimalFormat() const override;
 
  private:
   std::string hostname_;
   std::unique_ptr<MiracGstTestSource> gst_pipeline_;
   int sink_port1_;
   int sink_port2_;
-  wfd::H264VideoFormat format_;
+  wfd::SelectableH264VideoFormat format_;
 };
 
 #endif // DESKTOP_MEDIA_MANAGER_H_

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -64,11 +64,27 @@ std::string GstSinkMediaManager::Session() const {
 
 std::vector<wfd::SupportedH264VideoFormats>
 GstSinkMediaManager::GetSupportedH264VideoFormats() const {
-  return {wfd::SupportedH264VideoFormats()};
+  // declare that we support all resolutions, CHP and level 4.2
+  // gstreamer should handle all of it :)
+  std::vector<wfd::CEARatesAndResolutions> cea_rr;
+  std::vector<wfd::VESARatesAndResolutions> vesa_rr;
+  std::vector<wfd::HHRatesAndResolutions> hh_rr;
+  wfd::RateAndResolution i;
+
+  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i = i + 1)
+      cea_rr.push_back(wfd::CEARatesAndResolutions(i));
+  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i = i + 1)
+      vesa_rr.push_back(wfd::VESARatesAndResolutions(i));
+  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i = i + 1)
+      hh_rr.push_back(wfd::HHRatesAndResolutions(i));
+  return {wfd::SupportedH264VideoFormats(wfd::CHP, wfd::k4_2, cea_rr, vesa_rr, hh_rr),
+          wfd::SupportedH264VideoFormats(wfd::CBP, wfd::k4_2, cea_rr, vesa_rr, hh_rr)};
 }
 
 wfd::NativeVideoFormat GstSinkMediaManager::SupportedNativeVideoFormat() const {
-  return wfd::NativeVideoFormat();
+  // pick the maximum possible resolution, let gstreamer deal with it
+  // TODO: get the actual screen size of the system
+  return wfd::NativeVideoFormat(wfd::CEA1920x1080p60);
 }
 
 bool GstSinkMediaManager::SetOptimalFormat(

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -71,12 +71,12 @@ GstSinkMediaManager::GetSupportedH264VideoFormats() const {
   std::vector<wfd::HHRatesAndResolutions> hh_rr;
   wfd::RateAndResolution i;
 
-  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i = i + 1)
-      cea_rr.push_back(wfd::CEARatesAndResolutions(i));
-  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i = i + 1)
-      vesa_rr.push_back(wfd::VESARatesAndResolutions(i));
-  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i = i + 1)
-      hh_rr.push_back(wfd::HHRatesAndResolutions(i));
+  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i++)
+      cea_rr.push_back(static_cast<wfd::CEARatesAndResolutions>(i));
+  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i++)
+      vesa_rr.push_back(static_cast<wfd::VESARatesAndResolutions>(i));
+  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i++)
+      hh_rr.push_back(static_cast<wfd::HHRatesAndResolutions>(i));
   return {wfd::SupportedH264VideoFormats(wfd::CHP, wfd::k4_2, cea_rr, vesa_rr, hh_rr),
           wfd::SupportedH264VideoFormats(wfd::CBP, wfd::k4_2, cea_rr, vesa_rr, hh_rr)};
 }

--- a/sink/gst_sink_media_manager.cpp
+++ b/sink/gst_sink_media_manager.cpp
@@ -23,7 +23,7 @@
 
 GstSinkMediaManager::GstSinkMediaManager(const std::string& hostname)
   : gst_pipeline_(new MiracGstSink(hostname, 0)),
-    format_() {
+    optimal_format_ () {
 }
 
 void GstSinkMediaManager::Play() {
@@ -62,9 +62,9 @@ std::string GstSinkMediaManager::Session() const {
   return session_;
 }
 
-std::vector<wfd::H264VideoFormat>
-GstSinkMediaManager::SupportedH264VideoFormats() const {
-  return {format_};
+std::vector<wfd::SupportedH264VideoFormats>
+GstSinkMediaManager::GetSupportedH264VideoFormats() const {
+  return {wfd::SupportedH264VideoFormats()};
 }
 
 wfd::NativeVideoFormat GstSinkMediaManager::SupportedNativeVideoFormat() const {
@@ -72,12 +72,12 @@ wfd::NativeVideoFormat GstSinkMediaManager::SupportedNativeVideoFormat() const {
 }
 
 bool GstSinkMediaManager::SetOptimalFormat(
-    const wfd::H264VideoFormat& optimal_format) {
-  format_ = optimal_format;
+    const wfd::SelectableH264VideoFormat& optimal_format) {
+  optimal_format_ = optimal_format;
   return true;
 }
 
 
-wfd::H264VideoFormat GstSinkMediaManager::GetOptimalFormat() const {
-  return format_;
+wfd::SelectableH264VideoFormat GstSinkMediaManager::GetOptimalFormat() const {
+  return optimal_format_;
 }

--- a/sink/gst_sink_media_manager.h
+++ b/sink/gst_sink_media_manager.h
@@ -41,17 +41,17 @@ class GstSinkMediaManager : public wfd::SinkMediaManager {
   virtual void SetSession(const std::string& session) override;
   virtual std::string Session() const override;
 
-  virtual std::vector<wfd::H264VideoFormat> SupportedH264VideoFormats() const override;
+  virtual std::vector<wfd::SupportedH264VideoFormats> GetSupportedH264VideoFormats() const override;
   virtual wfd::NativeVideoFormat SupportedNativeVideoFormat() const override;
-  virtual bool SetOptimalFormat(const wfd::H264VideoFormat& optimal_format) override;
-  virtual wfd::H264VideoFormat GetOptimalFormat() const override;
+  virtual bool SetOptimalFormat(const wfd::SelectableH264VideoFormat& optimal_format) override;
+  virtual wfd::SelectableH264VideoFormat GetOptimalFormat() const override;
 
  private:
   std::string hostname_;
   std::string presentation_url_;
   std::string session_;
   std::unique_ptr<MiracGstSink> gst_pipeline_;
-  wfd::H264VideoFormat format_;
+  wfd::SelectableH264VideoFormat optimal_format_;
 };
 
 #endif // GST_SINK_MEDIA_MANAGER_H_

--- a/wfd/common/source_media_manager.cpp
+++ b/wfd/common/source_media_manager.cpp
@@ -108,25 +108,25 @@ static QualityInfo hh_info_table[] = {
 
 #define HH_TABLE_LENGTH  sizeof(hh_info_table) / sizeof(QualityInfo)
 
-QualityInfo get_cea_info(const H264VideoFormat& format) {
+QualityInfo get_cea_info(const SelectableH264VideoFormat& format) {
   if (format.rate_resolution > CEA_TABLE_LENGTH)
     assert(false);
   return cea_info_table[format.rate_resolution];
 }
 
-QualityInfo get_vesa_info(const H264VideoFormat& format) {
+QualityInfo get_vesa_info(const SelectableH264VideoFormat& format) {
   if (format.rate_resolution > VESA_TABLE_LENGTH)
     assert(false);
   return vesa_info_table[format.rate_resolution];
 }
 
-QualityInfo get_hh_info(const H264VideoFormat& format) {
+QualityInfo get_hh_info(const SelectableH264VideoFormat& format) {
   if (format.rate_resolution > HH_TABLE_LENGTH)
     assert(false);
   return hh_info_table[format.rate_resolution];
 }
 
-QualityInfo get_quality_info(const H264VideoFormat& format) {
+QualityInfo get_quality_info(const SelectableH264VideoFormat& format) {
   QualityInfo info;
   switch (format.type) {
   case CEA:
@@ -145,29 +145,29 @@ QualityInfo get_quality_info(const H264VideoFormat& format) {
   return info;
 }
 
-std::pair<uint, uint> get_resolution(const H264VideoFormat& format) {
+std::pair<uint, uint> get_resolution(const SelectableH264VideoFormat& format) {
   QualityInfo info = get_quality_info(format);
   return std::pair<uint, uint>(info.width, info.height);
 }
 
-bool operator == (const H264VideoFormat& a, const H264VideoFormat& b) {
+bool operator == (const SelectableH264VideoFormat& a, const SelectableH264VideoFormat& b) {
   return (a.type == b.type)
       && (get_resolution(a) == get_resolution(b));
 }
 
-bool operator < (const H264VideoFormat& a, const H264VideoFormat& b) {
+bool operator < (const SelectableH264VideoFormat& a, const SelectableH264VideoFormat& b) {
   return get_quality_info(a).weight < get_quality_info(b).weight;
 }
 
-bool video_format_sort_func(const H264VideoFormat& a, const H264VideoFormat& b) {
+bool video_format_sort_func(const SelectableH264VideoFormat& a, const SelectableH264VideoFormat& b) {
   return b < a;
 }
 
-H264VideoFormat SourceMediaManager::FindOptimalFormat(const NativeVideoFormat& native,
-      const std::vector<H264VideoFormat>& formats) const {
-  std::vector<H264VideoFormat> locally_supported_formats =
-      SupportedH264VideoFormats();
-  std::vector<H264VideoFormat> remotely_supported_formats = formats;
+SelectableH264VideoFormat SourceMediaManager::FindOptimalFormat(const NativeVideoFormat& native,
+      const std::vector<SelectableH264VideoFormat>& formats) const {
+  std::vector<SelectableH264VideoFormat> locally_supported_formats =
+      GetSelectableH264VideoFormats();
+  std::vector<SelectableH264VideoFormat> remotely_supported_formats = formats;
 
   std::sort(locally_supported_formats.begin(), locally_supported_formats.end(),
       video_format_sort_func);
@@ -177,8 +177,8 @@ H264VideoFormat SourceMediaManager::FindOptimalFormat(const NativeVideoFormat& n
   auto it = locally_supported_formats.begin();
   auto end = locally_supported_formats.end();
 
-  H264VideoFormat format(H264VideoFormat::CBP,
-      H264VideoFormat::k3_1, CEA640x480p60);
+  SelectableH264VideoFormat format(CBP,
+      k3_1, CEA640x480p60);
 
   while(it != end) {
     auto match = std::find(

--- a/wfd/common/source_media_manager.cpp
+++ b/wfd/common/source_media_manager.cpp
@@ -156,7 +156,11 @@ bool operator == (const SelectableH264VideoFormat& a, const SelectableH264VideoF
 }
 
 bool operator < (const SelectableH264VideoFormat& a, const SelectableH264VideoFormat& b) {
-  return get_quality_info(a).weight < get_quality_info(b).weight;
+  if (get_quality_info(a).weight != get_quality_info(b).weight)
+    return get_quality_info(a).weight < get_quality_info(b).weight;
+  if (a.profile != b.profile)
+    return a.profile < b.profile;
+  return a.level < b.level;
 }
 
 bool video_format_sort_func(const SelectableH264VideoFormat& a, const SelectableH264VideoFormat& b) {

--- a/wfd/parser/tests.cpp
+++ b/wfd/parser/tests.cpp
@@ -504,7 +504,7 @@ static bool test_valid_get_parameter_reply ()
   std::shared_ptr<wfd::VideoFormats> video_formats = std::static_pointer_cast<wfd::VideoFormats> (prop);
   ASSERT_EQUAL(video_formats->GetNativeFormat().rate_resolution, 8);
   ASSERT_EQUAL(video_formats->GetNativeFormat().type, 0);
-  ASSERT_EQUAL(video_formats->GetSupportedH264Formats().size(), 96);
+  ASSERT_EQUAL(video_formats->GetSelectableH264Formats().size(), 96);
 
   ASSERT_NO_EXCEPTION (prop =
       payload.get_property(wfd::PropertyType::WFD_3D_FORMATS));
@@ -701,7 +701,7 @@ static bool test_valid_set_parameter ()
   std::shared_ptr<wfd::VideoFormats> video_formats = std::static_pointer_cast<wfd::VideoFormats> (prop);
   ASSERT_EQUAL(video_formats->GetNativeFormat().rate_resolution, 11);
   ASSERT_EQUAL(video_formats->GetNativeFormat().type, 2);
-  ASSERT_EQUAL(video_formats->GetSupportedH264Formats().size(), 1);
+  ASSERT_EQUAL(video_formats->GetSelectableH264Formats().size(), 1);
 
   ASSERT_NO_EXCEPTION (prop =
       payload.get_property(wfd::PropertyType::WFD_CLIENT_RTP_PORTS));

--- a/wfd/parser/videoformats.cpp
+++ b/wfd/parser/videoformats.cpp
@@ -27,6 +27,19 @@
 
 namespace wfd {
 
+namespace {
+template <typename EnumType>
+unsigned int EnumListToMask(std::vector<EnumType> from) {
+  unsigned int result = 0;
+
+  for (auto item : from) {
+    result = result | (1 << item);
+  }
+
+  return result;
+}
+} //namespace
+
 H264Codec::H264Codec(unsigned char profile, unsigned char level,
     unsigned int cea_support, unsigned int vesa_support,
     unsigned int hh_support, unsigned char latency,
@@ -45,7 +58,7 @@ H264Codec::H264Codec(unsigned char profile, unsigned char level,
     max_hres_(max_hres),
     max_vres_(max_vres) {}
 
-H264Codec::H264Codec(H264VideoFormat format)
+H264Codec::H264Codec(SelectableH264VideoFormat format)
   : profile_(1 << format.profile),
     level_(1 << format.level),
     cea_support_((format.type == CEA) ? 1 << format.rate_resolution : 0),
@@ -59,6 +72,22 @@ H264Codec::H264Codec(H264VideoFormat format)
     max_vres_(0) {
 
 }
+
+H264Codec::H264Codec(SupportedH264VideoFormats format)
+  : profile_(1 << format.profile),
+    level_(1 << format.level),
+    cea_support_(EnumListToMask(format.cea_rr)),
+    vesa_support_(EnumListToMask(format.vesa_rr)),
+    hh_support_(EnumListToMask(format.hh_rr)),
+    latency_(0),
+    min_slice_size_(0),
+    slice_enc_params_(0),
+    frame_rate_control_support_(0),
+    max_hres_(0),
+    max_vres_(0) {
+
+}
+
 
 std::string H264Codec::ToString() const {
   std::string ret;
@@ -139,36 +168,36 @@ std::vector<EnumType> MaskToEnumList(ArgType from, EnumType biggest_value) {
   return result;
 }
 
-inline H264VideoFormat::H264Profile ToH264Profile(unsigned char profile) {
-  return MaskToEnum<H264VideoFormat::H264Profile>(profile, H264VideoFormat::CHP);
+inline H264Profile ToH264Profile(unsigned char profile) {
+  return MaskToEnum<H264Profile>(profile, CHP);
 }
 
-inline H264VideoFormat::H264Level ToH264Level(unsigned char level) {
-  return MaskToEnum<H264VideoFormat::H264Level>(level, H264VideoFormat::k4_2);
+inline H264Level ToH264Level(unsigned char level) {
+  return MaskToEnum<H264Level>(level, k4_2);
 }
 
 }  // namespace
 
-void H264Codec::ToVideoFormats(std::vector<H264VideoFormat>& formats) const {
+void H264Codec::ToSelectableVideoFormats(std::vector<SelectableH264VideoFormat>& formats) const {
   auto profile = ToH264Profile(profile_);
   auto level = ToH264Level(level_);
   if (cea_support_ != 0) {
     auto list = MaskToEnumList<CEARatesAndResolutions>(
         cea_support_, CEA1920x1080p24);
     for(auto rate_resolution: list)
-      formats.push_back(H264VideoFormat(profile, level, rate_resolution));
+      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
   }
   if (vesa_support_ != 0) {
     auto list = MaskToEnumList<VESARatesAndResolutions>(
         vesa_support_, VESA1920x1200p30);
     for(auto rate_resolution: list)
-      formats.push_back(H264VideoFormat(profile, level, rate_resolution));
+      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
   }
   if (hh_support_ != 0) {
     auto list = MaskToEnumList<HHRatesAndResolutions>(
         hh_support_, HH848x480p60);
     for(auto rate_resolution: list)
-      formats.push_back(H264VideoFormat(profile, level, rate_resolution));
+      formats.push_back(SelectableH264VideoFormat(profile, level, rate_resolution));
   }
 }
 
@@ -177,7 +206,17 @@ VideoFormats::VideoFormats() : Property(WFD_VIDEO_FORMATS, true) {
 
 VideoFormats::VideoFormats(NativeVideoFormat format,
     bool preferred_display_mode,
-    const std::vector<H264VideoFormat>& h264_formats)
+    const std::vector<SelectableH264VideoFormat>& h264_formats)
+  : Property(WFD_VIDEO_FORMATS),
+    preferred_display_mode_(preferred_display_mode ? 1 : 0) {
+  native_ = (format.rate_resolution << 3) | format.type;
+  for(auto h264_format : h264_formats)
+    h264_codecs_.push_back(H264Codec(h264_format));
+}
+
+VideoFormats::VideoFormats(NativeVideoFormat format,
+    bool preferred_display_mode,
+    const std::vector<SupportedH264VideoFormats>& h264_formats)
   : Property(WFD_VIDEO_FORMATS),
     preferred_display_mode_(preferred_display_mode ? 1 : 0) {
   native_ = (format.rate_resolution << 3) | format.type;
@@ -226,10 +265,10 @@ NativeVideoFormat VideoFormats::GetNativeFormat() const {
   return NativeVideoFormat(CEA640x480p60);
 }
 
-std::vector<H264VideoFormat> VideoFormats::GetSupportedH264Formats() const {
-  std::vector<H264VideoFormat> result;
+std::vector<SelectableH264VideoFormat> VideoFormats::GetSelectableH264Formats() const {
+  std::vector<SelectableH264VideoFormat> result;
   for (const auto& codec : h264_codecs_)
-    codec.ToVideoFormats(result);
+    codec.ToSelectableVideoFormats(result);
   return result;
 }
 

--- a/wfd/parser/videoformats.cpp
+++ b/wfd/parser/videoformats.cpp
@@ -29,7 +29,7 @@ namespace wfd {
 
 namespace {
 template <typename EnumType>
-unsigned int EnumListToMask(std::vector<EnumType> from) {
+unsigned int EnumListToMask(const std::vector<EnumType>& from) {
   unsigned int result = 0;
 
   for (auto item : from) {

--- a/wfd/parser/videoformats.h
+++ b/wfd/parser/videoformats.h
@@ -39,9 +39,11 @@ struct H264Codec {
       unsigned char frame_rate_control_support,
       unsigned short max_hres, unsigned short max_vres);
 
-  H264Codec(H264VideoFormat format);
+  H264Codec(SelectableH264VideoFormat format);
 
-  void ToVideoFormats(std::vector<H264VideoFormat>& formats) const;
+  H264Codec(SupportedH264VideoFormats format);
+
+  void ToSelectableVideoFormats(std::vector<SelectableH264VideoFormat>& formats) const;
 
   std::string ToString() const;
 
@@ -66,14 +68,17 @@ class VideoFormats: public Property {
   VideoFormats();
   VideoFormats(NativeVideoFormat format,
                bool preferred_display_mode,
-               const std::vector<H264VideoFormat>& h264_formats);
+               const std::vector<SelectableH264VideoFormat>& h264_formats);
+  VideoFormats(NativeVideoFormat format,
+               bool preferred_display_mode,
+               const std::vector<SupportedH264VideoFormats>& h264_formats);
   VideoFormats(unsigned char native,
                unsigned char preferred_display_mode,
                const H264Codecs& h264_codecs);
   ~VideoFormats() override;
 
   NativeVideoFormat GetNativeFormat() const;
-  std::vector<H264VideoFormat> GetSupportedH264Formats() const;
+  std::vector<SelectableH264VideoFormat> GetSelectableH264Formats() const;
 
   std::string ToString() const override;
 

--- a/wfd/public/media_manager.h
+++ b/wfd/public/media_manager.h
@@ -64,31 +64,19 @@ class MediaManager {
   virtual bool IsPaused() const = 0;
 
   /**
-   * Returns list of supported H264 video formats
-   * @return vector of supported H264 video formats
-   */
-  virtual std::vector<H264VideoFormat> SupportedH264VideoFormats() const = 0;
-
-  /**
-   * Returns native video format of a device
-   * @return native video format
-   */
-  virtual NativeVideoFormat SupportedNativeVideoFormat() const = 0;
-
-  /**
    * Sets optimal H264 format that would be used to send / receive video stream
    *
    * @param optimal H264 format
    * @return true if format can be used by media manager
    */
-  virtual bool SetOptimalFormat(const H264VideoFormat& optimal_format) = 0;
+  virtual bool SetOptimalFormat(const SelectableH264VideoFormat& optimal_format) = 0;
 
   /**
    * Gets optimal H264 format @see SetOptimalFormat
    *
    * @return optimal H264 format
    */
-  virtual H264VideoFormat GetOptimalFormat() const = 0;
+  virtual SelectableH264VideoFormat GetOptimalFormat() const = 0;
 };
 
 class SinkMediaManager : public MediaManager {
@@ -128,6 +116,17 @@ class SinkMediaManager : public MediaManager {
    */
   virtual std::string Session() const = 0;
 
+  /**
+   * Returns list of supported H264 video formats
+   * @return vector of supported H264 video formats
+   */
+  virtual std::vector<SupportedH264VideoFormats> GetSupportedH264VideoFormats() const = 0;
+
+  /**
+   * Returns native video format of a device
+   * @return native video format
+   */
+  virtual NativeVideoFormat SupportedNativeVideoFormat() const = 0;
 };
 
 class WFD_EXPORT SourceMediaManager : public MediaManager {
@@ -155,6 +154,12 @@ class WFD_EXPORT SourceMediaManager : public MediaManager {
   virtual int SourceRtpPort() const = 0;
 
   /**
+   * Returns list of supported H264 video formats
+   * @return vector of supported H264 video formats
+   */
+  virtual std::vector<SelectableH264VideoFormat> GetSelectableH264VideoFormats() const = 0;
+
+  /**
    * Finds optimal format for streaming.
    * Default quality selection algorithm will pick codec with higher bandwidth
    *
@@ -162,9 +167,9 @@ class WFD_EXPORT SourceMediaManager : public MediaManager {
    * @param list of H264 formats that are supported by remote device
    * @return optimal H264 video format
    */
-  virtual H264VideoFormat FindOptimalFormat(
+  virtual SelectableH264VideoFormat FindOptimalFormat(
       const NativeVideoFormat& remote_device_native_format,
-      const std::vector<H264VideoFormat>& remotely_supported_formats) const;
+      const std::vector<SelectableH264VideoFormat>& remotely_supported_formats) const;
 };
 
 inline SourceMediaManager* ToSourceMediaManager(MediaManager* mng) {

--- a/wfd/public/video_format.h
+++ b/wfd/public/video_format.h
@@ -131,6 +131,14 @@ struct NativeVideoFormat {
   RateAndResolution rate_resolution;
 };
 
+/**
+ * A single video format that the source selects for streaming.
+ *
+ * SelectableH264VideoFormat is a H264 profile, H264 level, and a single CEA,
+ * VESA or HH resolution. Sources are choosing the video format by matching what they
+ * support to what the sink supports, and then they communicate the chosen format back
+ * to the sink.
+ */
 struct SelectableH264VideoFormat {
   SelectableH264VideoFormat()
   : profile(CBP), level(k3_1), type(CEA), rate_resolution(CEA640x480p60) {}
@@ -150,14 +158,22 @@ struct SelectableH264VideoFormat {
   RateAndResolution rate_resolution;
 };
 
+/**
+ * A list of video formats supported by the sink.
+ *
+ * SupportedH264VideoFormats is a H264 profile, H264 level, and three sets of
+ * CEA, VESA and HH resolutions. Sinks send one or several SupportedH264VideoFormats
+ * to sources (for example because supported resolutions might
+ * be different for CBP and CHP).
+ */
 struct SupportedH264VideoFormats {
   SupportedH264VideoFormats()
   : profile(CBP), level(k3_1), cea_rr({CEA640x480p60}) {}
 
   SupportedH264VideoFormats(H264Profile profile, H264Level level,
-                  std::vector<CEARatesAndResolutions> cea,
-                  std::vector<VESARatesAndResolutions> vesa,
-                  std::vector<HHRatesAndResolutions> hh
+                  const std::vector<CEARatesAndResolutions>& cea,
+                  const std::vector<VESARatesAndResolutions>& vesa,
+                  const std::vector<HHRatesAndResolutions>& hh
                  )
   : profile(profile), level(level), cea_rr(cea), vesa_rr(vesa), hh_rr(hh) {}
 

--- a/wfd/public/video_format.h
+++ b/wfd/public/video_format.h
@@ -22,6 +22,8 @@
 #ifndef VIDEO_FORMAT_H_
 #define VIDEO_FORMAT_H_
 
+#include <vector>
+
 namespace wfd {
 
 typedef unsigned RateAndResolution;
@@ -101,6 +103,20 @@ enum HHRatesAndResolutions {
   HH848x480p60
 };
 
+enum H264Profile {
+  CBP,
+  CHP
+};
+
+enum H264Level {
+  k3_1,
+  k3_2,
+  k4,
+  k4_1,
+  k4_2
+};
+
+
 struct NativeVideoFormat {
   NativeVideoFormat()
   : type(CEA), rate_resolution(CEA640x480p60) {}
@@ -115,30 +131,17 @@ struct NativeVideoFormat {
   RateAndResolution rate_resolution;
 };
 
-struct H264VideoFormat {
-  enum H264Profile {
-    CBP,
-    CHP
-  };
-
-  enum H264Level {
-    k3_1,
-    k3_2,
-    k4,
-    k4_1,
-    k4_2
-  };
-
-  H264VideoFormat()
+struct SelectableH264VideoFormat {
+  SelectableH264VideoFormat()
   : profile(CBP), level(k3_1), type(CEA), rate_resolution(CEA640x480p60) {}
 
-  H264VideoFormat(H264Profile profile, H264Level level, CEARatesAndResolutions rr)
+  SelectableH264VideoFormat(H264Profile profile, H264Level level, CEARatesAndResolutions rr)
   : profile(profile), level(level), type(CEA), rate_resolution(rr) {}
 
-  H264VideoFormat(H264Profile profile, H264Level level, VESARatesAndResolutions rr)
+  SelectableH264VideoFormat(H264Profile profile, H264Level level, VESARatesAndResolutions rr)
   : profile(profile), level(level), type(VESA), rate_resolution(rr) {}
 
-  H264VideoFormat(H264Profile profile, H264Level level, HHRatesAndResolutions rr)
+  SelectableH264VideoFormat(H264Profile profile, H264Level level, HHRatesAndResolutions rr)
   : profile(profile), level(level), type(HH), rate_resolution(rr) {}
 
   H264Profile profile;
@@ -146,6 +149,25 @@ struct H264VideoFormat {
   ResolutionType type;
   RateAndResolution rate_resolution;
 };
+
+struct SupportedH264VideoFormats {
+  SupportedH264VideoFormats()
+  : profile(CBP), level(k3_1), cea_rr({CEA640x480p60}) {}
+
+  SupportedH264VideoFormats(H264Profile profile, H264Level level,
+                  std::vector<CEARatesAndResolutions> cea,
+                  std::vector<VESARatesAndResolutions> vesa,
+                  std::vector<HHRatesAndResolutions> hh
+                 )
+  : profile(profile), level(level), cea_rr(cea), vesa_rr(vesa), hh_rr(hh) {}
+
+  H264Profile profile;
+  H264Level level;
+  std::vector<CEARatesAndResolutions> cea_rr;
+  std::vector<VESARatesAndResolutions> vesa_rr;
+  std::vector<HHRatesAndResolutions> hh_rr;
+};
+
 
 }  // namespace wfd
 

--- a/wfd/source/cap_negotiation_state.cpp
+++ b/wfd/source/cap_negotiation_state.cpp
@@ -77,9 +77,9 @@ bool M3Handler::HandleReply(Reply* reply) {
   auto video_formats = static_cast<VideoFormats*>(
       reply->payload().get_property(WFD_VIDEO_FORMATS).get());
   assert(video_formats);
-  H264VideoFormat optimal_format = source_manager->FindOptimalFormat(
+  SelectableH264VideoFormat optimal_format = source_manager->FindOptimalFormat(
       video_formats->GetNativeFormat(),
-      video_formats->GetSupportedH264Formats());
+      video_formats->GetSelectableH264Formats());
   return source_manager->SetOptimalFormat(optimal_format);
 }
 
@@ -96,7 +96,7 @@ std::unique_ptr<Message> M4Handler::CreateMessage() {
 
   set_param->payload().add_property(
       std::shared_ptr<VideoFormats>(new VideoFormats(
-          manager_->SupportedNativeVideoFormat(),
+          NativeVideoFormat(),
           false,
           {manager_->GetOptimalFormat()})));
 


### PR DESCRIPTION
Video format declarations weren't suitable for sinks, so these patches fix the problem.

Also, gstreamer source and sink now declare that they support everything (instead of just basic 640x480), and the format selector now considers also profile and level when comparing formats. It would be good to test with 3rd party sources and sinks if that affects (improves) the stream quality.

The exchange between our source and sink looks like this now:

(desktop-source-test:27619): rtsp-DEBUG: Sending RTSP message:
GET_PARAMETER rtsp://localhost/wfd1.0 RTSP/1.0
CSeq: 2
Content-Type: text/parameters
Content-Length: 59

wfd_video_formats
wfd_audio_codecs
wfd_client_rtp_ports

(desktop-source-test:27619): rtsp-DEBUG: Received RTSP message:
RTSP/1.0 200 OK
CSeq: 2
Content-Type: text/parameters
Content-Length: 276

wfd_audio_codecs: LPCM 00000003 00, AAC 0000000F 00, AC3 00000007 00
wfd_client_rtp_ports: RTP/AVP/UDP;unicast 51066 0 mode=play
wfd_video_formats: 40 00 02 10 0001FFFF 1FFFFFFF 00000FFF 00 0000 0000 00 none none, 01 10 0001FFFF 1FFFFFFF 00000FFF 00 0000 0000 00 none none

(desktop-source-test:27619): rtsp-DEBUG: Sending RTSP message:
SET_PARAMETER rtsp://localhost/wfd1.0 RTSP/1.0
CSeq: 3
Content-Type: text/parameters
Content-Length: 209

wfd_client_rtp_ports: RTP/AVP/UDP;unicast 51066 0 mode=play
wfd_presentation_URL: rtsp://127.0.0.1/wfd1.0/streamid=0 none
wfd_video_formats: 00 00 02 10 00000100 00000000 00000000 00 0000 0000 00 none none

(desktop-source-test:27619): rtsp-DEBUG: Received RTSP message:
RTSP/1.0 200 OK
CSeq: 3


