### PR TITLE
Fix MediaManager video format API

### DIFF
--- a/desktop_source/desktop_media_manager.cpp
+++ b/desktop_source/desktop_media_manager.cpp
@@ -43,23 +43,27 @@ int DesktopMediaManager::GetLocalRtpPort() const {
 
 std::vector<wfd::SelectableH264VideoFormat>
 DesktopMediaManager::GetSelectableH264VideoFormats() const {
-  std::vector<wfd::SelectableH264VideoFormat> formats;
-
-  wfd::RateAndResolution i;
-
-  for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i++)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::CEARatesAndResolutions>(i)));
-  for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i++)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::VESARatesAndResolutions>(i)));
-  for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i++)
-      formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::HHRatesAndResolutions>(i)));
+  static std::vector<wfd::SelectableH264VideoFormat> formats;
+  if (formats.empty()) {
+    wfd::RateAndResolution i;
+    for (i = wfd::CEA640x480p60; i <= wfd::CEA1920x1080p24; i++)
+        formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::CEARatesAndResolutions>(i)));
+    for (i = wfd::VESA800x600p30; i <= wfd::VESA1920x1200p30; i++)
+        formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::VESARatesAndResolutions>(i)));
+    for (i = wfd::HH800x480p30; i <= wfd::HH848x480p60; i++)
+        formats.push_back(wfd::SelectableH264VideoFormat(wfd::CHP, wfd::k4_2, static_cast<wfd::HHRatesAndResolutions>(i)));
+  }
 
   return formats;
 }
 
-bool DesktopMediaManager::SetOptimalVideoFormat(
-    const wfd::SelectableH264VideoFormat& optimal_format) {
-  format_ = optimal_format;
+bool DesktopMediaManager::InitOptimalVideoFormat(
+    const wfd::NativeVideoFormat& sink_native_format,
+    const std::vector<wfd::SelectableH264VideoFormat>& sink_supported_formats) {
+
+  format_ = wfd::FindOptimalVideoFormat(sink_native_format,
+                                        GetSelectableH264VideoFormats(),
+                                        sink_supported_formats);
   return true;
 }
 

--- a/desktop_source/desktop_media_manager.h
+++ b/desktop_source/desktop_media_manager.h
@@ -18,7 +18,9 @@ class DesktopMediaManager : public wfd::SourceMediaManager {
   int GetLocalRtpPort() const override;
 
   std::vector<wfd::SelectableH264VideoFormat> GetSelectableH264VideoFormats() const override;
-  bool SetOptimalVideoFormat(const wfd::SelectableH264VideoFormat& optimal_format) override;
+  bool InitOptimalVideoFormat(
+      const wfd::NativeVideoFormat& sink_native_format,
+      const std::vector<wfd::SelectableH264VideoFormat>& sink_supported_formats) override;
   wfd::SelectableH264VideoFormat GetOptimalVideoFormat() const override;
   bool InitOptimalAudioFormat(const std::vector<wfd::AudioCodec>& sink_supported_codecs) override;
   wfd::AudioCodec GetOptimalAudioFormat() const override;

--- a/wfd/common/source_media_manager.cpp
+++ b/wfd/common/source_media_manager.cpp
@@ -175,30 +175,28 @@ bool video_format_sort_func(const SelectableH264VideoFormat& a, const Selectable
   return b < a;
 }
 
-SelectableH264VideoFormat SourceMediaManager::FindOptimalVideoFormat(const NativeVideoFormat& native,
-      const std::vector<SelectableH264VideoFormat>& formats) const {
-  std::vector<SelectableH264VideoFormat> locally_supported_formats =
-      GetSelectableH264VideoFormats();
-  std::vector<SelectableH264VideoFormat> remotely_supported_formats = formats;
-
-  std::sort(locally_supported_formats.begin(), locally_supported_formats.end(),
+SelectableH264VideoFormat FindOptimalVideoFormat(
+    const NativeVideoFormat& native,
+    std::vector<SelectableH264VideoFormat> local_formats,
+    std::vector<SelectableH264VideoFormat> remote_formats) {
+  std::sort(local_formats.begin(), local_formats.end(),
       video_format_sort_func);
-  std::sort(remotely_supported_formats.begin(), remotely_supported_formats.end(),
+  std::sort(remote_formats.begin(), remote_formats.end(),
       video_format_sort_func);
 
-  auto it = locally_supported_formats.begin();
-  auto end = locally_supported_formats.end();
+  auto it = local_formats.begin();
+  auto end = local_formats.end();
 
   SelectableH264VideoFormat format(CBP,
       k3_1, CEA640x480p60);
 
   while(it != end) {
     auto match = std::find(
-        remotely_supported_formats.begin(),
-        remotely_supported_formats.end(),
+        remote_formats.begin(),
+        remote_formats.end(),
         *it);
 
-    if (match != remotely_supported_formats.end()) {
+    if (match != remote_formats.end()) {
       format = *match;
       break;
     }


### PR DESCRIPTION
Put source-specific API to SourceMediaManager class. Align method names with audio codec API.